### PR TITLE
Apply the fontconfig font mappings only off Windows

### DIFF
--- a/src/Stampeded/Program.cs
+++ b/src/Stampeded/Program.cs
@@ -33,13 +33,18 @@ internal static class Program
 
 	public static AppBuilder BuildAvaloniaApp()
 	{
-		return AppBuilder.Configure<App>()
+		var builder = AppBuilder.Configure<App>()
 			.UsePlatformDetect()
 			.With(new X11PlatformOptions { OverlayPopups = true })
-			// Third-party styles (e.g. Markdown.Avalonia's code spans) name Windows
-			// fonts outright; an unresolvable family name aborts the layout pass, so
-			// map the usual suspects to the fontconfig monospace alias.
-			.With(new Avalonia.Media.FontManagerOptions {
+			.LogToTrace();
+		// Third-party styles (e.g. Markdown.Avalonia's code spans) name Windows
+		// fonts outright; an unresolvable family name aborts the layout pass, so
+		// map the usual suspects to the fontconfig monospace alias. Only where
+		// fontconfig exists: on Windows the named fonts are real and the aliases
+		// are the unresolvable ones - with them in place even the default
+		// typeface fails to produce a glyph typeface and no window ever shows.
+		if (!OperatingSystem.IsWindows())
+			builder = builder.With(new Avalonia.Media.FontManagerOptions {
 				FontFamilyMappings = new Dictionary<string, Avalonia.Media.FontFamily> {
 					["Consolas"] = new("monospace"),
 					["Menlo"] = new("monospace"),
@@ -48,7 +53,7 @@ internal static class Program
 					["Cascadia Code"] = new("monospace"),
 					["Segoe UI"] = new("sans-serif"),
 				},
-			})
-			.LogToTrace();
+			});
+		return builder;
 	}
 }


### PR DESCRIPTION
## Problem

On Windows, Stampeded launched but never opened a window. The process was crashing during the very first layout pass, before the main window could show:

```
Unhandled exception. System.InvalidOperationException: Could not create glyphTypeface.
Font family: Inter (key: compositefont:fonts:Inter#Inter, $Default)
   at Avalonia.Media.Typeface.get_GlyphTypeface()
   ...
   at Avalonia.Layout.LayoutManager.ExecuteInitialLayoutPass()
   at Avalonia.Controls.Window.Show()
```

The `FontManagerOptions` block in `Program.cs` was written for Linux: it maps font families that third-party styles name outright (Consolas, Menlo, Segoe UI, ...) to the fontconfig aliases `monospace` and `sans-serif`. Those aliases only exist under fontconfig. On Windows they resolve to nothing, and with the mappings active even Avalonia's embedded default font (Inter) fails to produce a glyph typeface, so the initial measure pass throws and the process exits silently - no window, no visible error.

## Fix

Apply the mappings only when not on Windows. The fonts being remapped are real system fonts there, so no mapping is needed at all. Linux behavior is unchanged.

Verified on Windows 11 via the app's self-screenshot mechanism: the window opens and renders correctly (note: the `/tmp/stampeded-screenshot-request` trigger path resolves to `<drive>:\tmp\` on Windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)