### PR TITLE
Run on a newer major runtime than the one built against

### DIFF
--- a/src/Stampeded/Stampeded.csproj
+++ b/src/Stampeded/Stampeded.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" />


### PR DESCRIPTION
`<RollForward>Major</RollForward>` on the app project.

The app targets `net10.0`, but a machine may only have a newer major runtime installed (here: .NET 11). The default roll-forward policy only spans minor versions, so `Stampeded` refuses to start with a framework-not-found error rather than using the runtime that is present.

Only the executable carries the property - `Stampeded.Core` and the test project get their runtime resolution from whatever host loads them.

Verified by launching the app and driving a self-screenshot; the window comes up as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)