### PR TITLE
Build, test and package on Windows, Linux and macOS in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            rid: win-x64
+          - os: ubuntu-latest
+            rid: linux-x64
+          - os: macos-latest
+            rid: osx-arm64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - run: dotnet build Stampeded.slnx -c Release
+      - run: dotnet test Stampeded.slnx -c Release --no-build
+
+      # Framework-dependent on purpose: the app needs an installed .NET SDK at runtime
+      # anyway (Roslyn's MSBuild workspace, dotnet build/test), so bundling a runtime
+      # would only grow the artifact. RID-specific so an apphost exists to launch.
+      - run: dotnet publish src/Stampeded/Stampeded.csproj -c Release -r ${{ matrix.rid }} --no-self-contained -o publish/${{ matrix.rid }}
+
+      - name: Zip (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Compress-Archive -Path publish/win-x64/* -DestinationPath Stampeded-win-x64.zip
+
+      # Info-ZIP keeps the execute bit; Compress-Archive and upload-artifact drop it.
+      - name: Zip (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: cd publish/linux-x64 && zip -r -q ../../Stampeded-linux-x64.zip .
+
+      # Unsigned and unnotarized: first launch needs `xattr -dr com.apple.quarantine Stampeded.app`.
+      - name: dmg (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          mkdir dmg
+          cp -R publish/osx-arm64/Stampeded.app dmg/
+          ln -s /Applications dmg/Applications
+          hdiutil create -volname Stampeded -srcfolder dmg -ov -format UDZO Stampeded-macos-arm64.dmg
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Stampeded-${{ matrix.rid }}
+          path: |
+            Stampeded-*.zip
+            Stampeded-*.dmg
+          if-no-files-found: error

--- a/src/Stampeded/Assets/macos/Info.plist
+++ b/src/Stampeded/Assets/macos/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleName</key>
+  <string>Stampeded</string>
+  <key>CFBundleDisplayName</key>
+  <string>Stampeded</string>
+  <key>CFBundleIdentifier</key>
+  <string>net.icsharpcode.stampeded</string>
+  <key>CFBundleVersion</key>
+  <string>0.1.0</string>
+  <key>CFBundleShortVersionString</key>
+  <string>0.1.0</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleExecutable</key>
+  <string>Stampeded</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>11.0</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
+</dict>
+</plist>

--- a/src/Stampeded/Stampeded.csproj
+++ b/src/Stampeded/Stampeded.csproj
@@ -24,4 +24,22 @@
     <AvaloniaResource Include="Assets/**/*.svg" />
     <EmbeddedResource Include="Editor/ILAsm-Mode.xshd" />
   </ItemGroup>
+  <!-- macOS runs an application out of a .app directory, not a loose folder of files. The
+       bundle is assembled here, on the publish target, so a plain
+       `dotnet publish -r osx-arm64` reproduces what CI ships, with nothing that exists only in
+       the workflow. The file list is taken before the bundle directory is created, so the
+       bundle never copies itself. No CFBundleIconFile: there is no .icns yet. -->
+  <Target Name="BuildMacAppBundle" AfterTargets="Publish" Condition="$(RuntimeIdentifier.StartsWith('osx-'))">
+    <PropertyGroup>
+      <_MacBundleContents>$(PublishDir)$(AssemblyName).app/Contents</_MacBundleContents>
+    </PropertyGroup>
+    <ItemGroup>
+      <_MacPublishFiles Include="$(PublishDir)**/*" Exclude="$(PublishDir)$(AssemblyName).app/**" />
+    </ItemGroup>
+    <RemoveDir Directories="$(PublishDir)$(AssemblyName).app" />
+    <Copy SourceFiles="@(_MacPublishFiles)" DestinationFiles="@(_MacPublishFiles->'$(_MacBundleContents)/MacOS/%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="$(MSBuildProjectDirectory)/Assets/macos/Info.plist" DestinationFolder="$(_MacBundleContents)" />
+    <Exec Command="chmod +x &quot;$(_MacBundleContents)/MacOS/$(AssemblyName)&quot;" Condition="!$([MSBuild]::IsOSPlatform('Windows'))" />
+    <Message Importance="high" Text="macOS bundle written to $(PublishDir)$(AssemblyName).app" />
+  </Target>
 </Project>

--- a/tests/Stampeded.Core.Tests/BuildArtifactCleanupTests.cs
+++ b/tests/Stampeded.Core.Tests/BuildArtifactCleanupTests.cs
@@ -18,13 +18,7 @@ public class BuildArtifactCleanupTests
 	[TearDown]
 	public void TearDown()
 	{
-		try
-		{
-			Directory.Delete(root, recursive: true);
-		}
-		catch (IOException)
-		{
-		}
+		TempDirectory.Delete(root);
 	}
 
 	static void WriteFile(string directory, string name)

--- a/tests/Stampeded.Core.Tests/DecompilationServiceTests.cs
+++ b/tests/Stampeded.Core.Tests/DecompilationServiceTests.cs
@@ -72,7 +72,7 @@ public class DecompilationServiceTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 }

--- a/tests/Stampeded.Core.Tests/DraftEditTests.cs
+++ b/tests/Stampeded.Core.Tests/DraftEditTests.cs
@@ -31,7 +31,7 @@ public class DraftEditTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 
@@ -54,7 +54,7 @@ public class DraftEditTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 
@@ -74,7 +74,7 @@ public class DraftEditTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 
@@ -99,7 +99,7 @@ public class DraftEditTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 }

--- a/tests/Stampeded.Core.Tests/EnclosingMemberTests.cs
+++ b/tests/Stampeded.Core.Tests/EnclosingMemberTests.cs
@@ -61,7 +61,7 @@ public class EnclosingMemberTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 
@@ -98,7 +98,7 @@ public class EnclosingMemberTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 

--- a/tests/Stampeded.Core.Tests/GeneratedSourcesTests.cs
+++ b/tests/Stampeded.Core.Tests/GeneratedSourcesTests.cs
@@ -19,13 +19,7 @@ public class GeneratedSourcesTests
 	{
 		foreach (var dir in temporaryDirectories)
 		{
-			try
-			{
-				Directory.Delete(dir, recursive: true);
-			}
-			catch (IOException)
-			{
-			}
+			TempDirectory.Delete(dir);
 		}
 		temporaryDirectories.Clear();
 	}

--- a/tests/Stampeded.Core.Tests/GitBlobReaderTests.cs
+++ b/tests/Stampeded.Core.Tests/GitBlobReaderTests.cs
@@ -28,13 +28,7 @@ public class GitBlobReaderTests
 	{
 		foreach (var dir in temporaryDirectories)
 		{
-			try
-			{
-				Directory.Delete(dir, recursive: true);
-			}
-			catch (IOException)
-			{
-			}
+			TempDirectory.Delete(dir);
 		}
 		temporaryDirectories.Clear();
 	}

--- a/tests/Stampeded.Core.Tests/GitInterdiffTests.cs
+++ b/tests/Stampeded.Core.Tests/GitInterdiffTests.cs
@@ -30,13 +30,7 @@ public class GitInterdiffTests
 	{
 		foreach (var dir in temporaryDirectories)
 		{
-			try
-			{
-				Directory.Delete(dir, recursive: true);
-			}
-			catch (IOException)
-			{
-			}
+			TempDirectory.Delete(dir);
 		}
 		temporaryDirectories.Clear();
 	}

--- a/tests/Stampeded.Core.Tests/GitMergeStateTests.cs
+++ b/tests/Stampeded.Core.Tests/GitMergeStateTests.cs
@@ -30,13 +30,7 @@ public class GitMergeStateTests
 	{
 		foreach (var dir in temporaryDirectories)
 		{
-			try
-			{
-				Directory.Delete(dir, recursive: true);
-			}
-			catch (IOException)
-			{
-			}
+			TempDirectory.Delete(dir);
 		}
 		temporaryDirectories.Clear();
 	}
@@ -160,10 +154,11 @@ public class GitMergeStateTests
 		await Git("branch", "already-in");
 		string worktree = NewDirectory();
 		await Git("worktree", "add", "--quiet", worktree, "already-in");
+		string worktreeAsGitReportsIt = await AsGitReports(worktree);
 
 		var deletion = await new GitService(repo).DeleteBranchAsync("already-in");
 
-		Assert.That(deletion.RemovedWorktree, Is.EqualTo(worktree));
+		Assert.That(deletion.RemovedWorktree, Is.EqualTo(worktreeAsGitReportsIt));
 		Assert.That(Directory.Exists(worktree), Is.False);
 		Assert.That(await Git("branch", "--format=%(refname:short)"), Does.Not.Contain("already-in"));
 	}
@@ -205,13 +200,14 @@ public class GitMergeStateTests
 		await Git("branch", "already-in");
 		string worktree = NewDirectory();
 		await Git("worktree", "add", "--quiet", worktree, "already-in");
+		string worktreeAsGitReportsIt = await AsGitReports(worktree);
 
 		var deletion = await new GitService(repo).DeleteBranchAsync("already-in");
 
-		Assert.That(deletion.RemovedWorktree, Is.EqualTo(worktree));
+		Assert.That(deletion.RemovedWorktree, Is.EqualTo(worktreeAsGitReportsIt));
 		Assert.That(Directory.Exists(worktree), Is.False);
 		Assert.That(await Git("branch", "--format=%(refname:short)"), Does.Not.Contain("already-in"));
-		Assert.That(await Git("worktree", "list", "--porcelain"), Does.Not.Contain(worktree),
+		Assert.That(await Git("worktree", "list", "--porcelain"), Does.Not.Contain(worktreeAsGitReportsIt),
 			"the administrative entry has to go with the directory");
 	}
 
@@ -273,4 +269,9 @@ public class GitMergeStateTests
 	}
 
 	Task<string> Git(params string[] args) => ExternalTool.RunAsync("git", args, repo);
+
+	/// <summary>The path in the form git prints it - forward slashes on Windows, symlinks
+	/// resolved on macOS - which is the form the service passes on unchanged.</summary>
+	static async Task<string> AsGitReports(string dir)
+		=> (await ExternalTool.RunAsync("git", ["rev-parse", "--show-toplevel"], dir)).Trim();
 }

--- a/tests/Stampeded.Core.Tests/GitPushTests.cs
+++ b/tests/Stampeded.Core.Tests/GitPushTests.cs
@@ -35,13 +35,7 @@ public class GitPushTests
 	{
 		foreach (var dir in temporaryDirectories)
 		{
-			try
-			{
-				Directory.Delete(dir, recursive: true);
-			}
-			catch (IOException)
-			{
-			}
+			TempDirectory.Delete(dir);
 		}
 		temporaryDirectories.Clear();
 	}

--- a/tests/Stampeded.Core.Tests/GitRebaseTests.cs
+++ b/tests/Stampeded.Core.Tests/GitRebaseTests.cs
@@ -36,13 +36,7 @@ public class GitRebaseTests
 	{
 		foreach (var dir in temporaryDirectories)
 		{
-			try
-			{
-				Directory.Delete(dir, recursive: true);
-			}
-			catch (IOException)
-			{
-			}
+			TempDirectory.Delete(dir);
 		}
 		temporaryDirectories.Clear();
 	}
@@ -67,6 +61,7 @@ public class GitRebaseTests
 	{
 		string worktree = NewDirectory();
 		await Git(repo, "worktree", "add", "--quiet", worktree, "topic");
+		string worktreeAsGitReportsIt = await AsGitReports(worktree);
 
 		var git = new GitService(repo);
 		var result = await git.RebaseBranchAsync("topic", "main");
@@ -75,14 +70,14 @@ public class GitRebaseTests
 			"topic should now sit on top of main");
 		// The checkout that holds the branch has to move with it, or its index and working
 		// tree describe a commit the branch no longer points at.
-		Assert.That(result.Checkout, Is.EqualTo(worktree));
+		Assert.That(result.Checkout, Is.EqualTo(worktreeAsGitReportsIt));
 		Assert.That((await Git(worktree, "rev-parse", "HEAD")).Trim(), Is.EqualTo(await RevParse("topic")));
 		Assert.That((await Git(worktree, "status", "--porcelain")).Trim(), Is.Empty);
 		Assert.That(File.Exists(Path.Combine(worktree, "main.txt")), Is.True,
 			"the rebased checkout should have main's file");
 
 		// The recovery the UI offers has to work here, and git branch -f would be refused.
-		Assert.That(result.RecoveryCommand("topic"), Is.EqualTo($"git -C {worktree} reset --hard {result.Before[..9]}"));
+		Assert.That(result.RecoveryCommand("topic"), Is.EqualTo($"git -C {worktreeAsGitReportsIt} reset --hard {result.Before[..9]}"));
 		await Git(worktree, "reset", "--hard", result.Before);
 		Assert.That(await RevParse("topic"), Is.EqualTo(result.Before));
 	}
@@ -175,6 +170,11 @@ public class GitRebaseTests
 	}
 
 	Task<string> Git(string dir, params string[] args) => ExternalTool.RunAsync("git", args, dir);
+
+	/// <summary>The path in the form git prints it - forward slashes on Windows, symlinks
+	/// resolved on macOS - which is the form the service passes on unchanged.</summary>
+	static async Task<string> AsGitReports(string dir)
+		=> (await ExternalTool.RunAsync("git", ["rev-parse", "--show-toplevel"], dir)).Trim();
 
 	async Task<string> RevParse(string reference) => (await Git(repo, "rev-parse", reference)).Trim();
 

--- a/tests/Stampeded.Core.Tests/ReReviewTests.cs
+++ b/tests/Stampeded.Core.Tests/ReReviewTests.cs
@@ -43,7 +43,7 @@ public class ReReviewTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 
@@ -73,7 +73,7 @@ public class ReReviewTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 
@@ -101,7 +101,7 @@ public class ReReviewTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 }

--- a/tests/Stampeded.Core.Tests/SideBySideBuilderTests.cs
+++ b/tests/Stampeded.Core.Tests/SideBySideBuilderTests.cs
@@ -7,20 +7,21 @@ namespace Stampeded.Core.Tests;
 [TestFixture]
 public class SideBySideBuilderTests
 {
-	const string OldText = """
+	// Raw literals take the line endings of the checkout; the builder speaks LF.
+	static readonly string OldText = """
 		line a
 		line b
 		line c
 		line d
-		""";
+		""".ReplaceLineEndings("\n");
 
-	const string NewText = """
+	static readonly string NewText = """
 		line a
 		line b CHANGED
 		line c
 		inserted line
 		line d
-		""";
+		""".ReplaceLineEndings("\n");
 
 	[Test]
 	public void SidesHaveEqualLineCounts()

--- a/tests/Stampeded.Core.Tests/SolutionTargetTests.cs
+++ b/tests/Stampeded.Core.Tests/SolutionTargetTests.cs
@@ -21,7 +21,7 @@ public class SolutionTargetTests
 	public void TearDown()
 	{
 		if (Directory.Exists(root))
-			Directory.Delete(root, recursive: true);
+			TempDirectory.Delete(root);
 	}
 
 	void Write(string name, int size) => File.WriteAllText(Path.Combine(root, name), new string('x', size));

--- a/tests/Stampeded.Core.Tests/TempDirectory.cs
+++ b/tests/Stampeded.Core.Tests/TempDirectory.cs
@@ -1,0 +1,29 @@
+namespace Stampeded.Core.Tests;
+
+/// <summary>Removes a directory a test created under the temp folder. git writes its loose
+/// objects read-only, and on Windows Directory.Delete refuses a read-only file, so the flag is
+/// cleared first. Removal is best effort: a directory that cannot go is a leak in the temp
+/// folder, not a verdict on what the test asserted.</summary>
+static class TempDirectory
+{
+	public static void Delete(string dir)
+	{
+		if (!Directory.Exists(dir))
+			return;
+		try
+		{
+			// Reparse points are skipped so a symlink a test planted is not followed out of
+			// the directory being cleaned.
+			var options = new EnumerationOptions { RecurseSubdirectories = true, AttributesToSkip = FileAttributes.ReparsePoint };
+			foreach (var file in Directory.EnumerateFiles(dir, "*", options))
+				File.SetAttributes(file, FileAttributes.Normal);
+			Directory.Delete(dir, recursive: true);
+		}
+		catch (IOException)
+		{
+		}
+		catch (UnauthorizedAccessException)
+		{
+		}
+	}
+}

--- a/tests/Stampeded.Core.Tests/WorkspacePathTests.cs
+++ b/tests/Stampeded.Core.Tests/WorkspacePathTests.cs
@@ -31,7 +31,7 @@ public class WorkspacePathTests
 		}
 		finally
 		{
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 
@@ -53,8 +53,8 @@ public class WorkspacePathTests
 		}
 		finally
 		{
-			Directory.Delete(root, recursive: true);
-			Directory.Delete(sibling, recursive: true);
+			TempDirectory.Delete(root);
+			TempDirectory.Delete(sibling);
 		}
 	}
 }

--- a/tests/Stampeded.Core.Tests/WorktreeCacheTests.cs
+++ b/tests/Stampeded.Core.Tests/WorktreeCacheTests.cs
@@ -34,13 +34,7 @@ public class WorktreeCacheTests
 		Environment.SetEnvironmentVariable("XDG_CACHE_HOME", null);
 		foreach (var dir in temporaryDirectories)
 		{
-			try
-			{
-				Directory.Delete(dir, recursive: true);
-			}
-			catch (IOException)
-			{
-			}
+			TempDirectory.Delete(dir);
 		}
 		temporaryDirectories.Clear();
 	}


### PR DESCRIPTION
## Why

Nothing built the solution outside a developer machine, and nothing produced a runnable artifact. One workflow now builds `Stampeded.slnx`, runs the tests and publishes a Release build on each OS's native runner: a zip for win-x64 and linux-x64, an unsigned, unnotarized dmg for osx-arm64.

## What

- `.github/workflows/build.yml`: matrix over `windows-latest` / `ubuntu-latest` / `macos-latest` (arm64). Build, test, framework-dependent RID-specific publish, then package. Info-ZIP on Linux so the execute bit survives; `hdiutil` for the dmg.
- `src/Stampeded/Stampeded.csproj`: `BuildMacAppBundle` target assembles `Stampeded.app` on any `osx-*` publish, so `dotnet publish -r osx-arm64` reproduces what CI ships.
- `src/Stampeded/Assets/macos/Info.plist`: minimal bundle manifest (no icon - there is no `.icns` yet).

Framework-dependent on purpose: the app needs an installed .NET SDK at runtime anyway (Roslyn MSBuild workspace, MSBuildLocator, `dotnet build`/`test`).

Modeled on icsharpcode/ILSpy#3768, minus deb/rpm, Homebrew, signing and pwsh packaging scripts, which wait for a release process.

## Verified locally

`dotnet publish -r osx-arm64` (cross-published from Windows) writes `publish/osx-arm64/Stampeded.app/Contents/{Info.plist,MacOS/Stampeded}` with all 116 publish files and is idempotent; `-r win-x64` yields `Stampeded.exe`. CI on this PR is the first run of the workflow itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011EuGx5KH6zfiZQYHTcygyh