### PR TITLE
Put the menu where each platform keeps its menus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,12 @@ results and coverage, in one Avalonia window. See `README.md` for the pitch.
   document rows (`SyntaxPainter`, `DiffSyntaxColors`) - a grammar is a state machine over
   consecutive lines, and a unified diff is consecutive on neither side. The editor's own xshd
   definitions answer for what the bundle does not carry, which is ILAsm.
+- The menu bar is a **NativeMenu**, not a `Menu`: macOS puts it in the system menu bar and
+  `NativeMenuBar` draws it inside the window everywhere else, hiding itself where the platform
+  took it. A menu item is a model object rather than a control, so it takes no `x:Name` (each
+  one the code-behind reaches carries a key as its `CommandParameter` instead), has no
+  `ItemsSource`, and shows a gesture only as text unless `Gesture` is set - which on macOS
+  registers a real key equivalent that fires before the focused text box sees the key.
 - **CliWrap** for every external process.
 - Target framework `net10.0`. Nullable enabled, implicit usings, `TreatWarningsAsErrors`,
   central package management (a new `PackageReference` needs a `PackageVersion` in

--- a/src/Stampeded/App.axaml
+++ b/src/Stampeded/App.axaml
@@ -5,7 +5,15 @@
              xmlns:controls="using:Stampeded.Controls"
              xmlns:local="using:Stampeded"
              x:Class="Stampeded.App"
+             Name="Stampeded"
              RequestedThemeVariant="Default">
+  <!-- The bold app-named menu macOS puts next to the Apple logo. Empty on purpose: Avalonia
+       synthesises one headed "About Avalonia" for an application that declares none, and then
+       appends the Services / Hide / Quit block to whichever it ends up with. Inert everywhere
+       else. -->
+  <NativeMenu.Menu>
+    <NativeMenu />
+  </NativeMenu.Menu>
   <Application.Resources>
     <ResourceDictionary>
       <ResourceDictionary.ThemeDictionaries>
@@ -98,6 +106,13 @@
          outranks the theme's ControlTheme, the way ILSpy paints the same part. -->
     <Style Selector="dockControls|DocumentControl:active /template/ Panel#PART_DocumentSeperator">
       <Setter Property="Background" Value="{x:Static local:ScopePalette.Accent}" />
+    </Style>
+    <!-- Why a command is unavailable is the question a greyed-out item raises, and its tooltip
+         is the answer - but a NativeMenuItem carries only the text, not that flag, so it is set
+         for every menu item at once. Concerns the in-window menu bar; macOS shows a native menu
+         item's tooltip either way. -->
+    <Style Selector="MenuItem">
+      <Setter Property="ToolTip.ShowOnDisabled" Value="True" />
     </Style>
     <Style Selector="OverlayPopupHost">
       <Setter Property="RenderTransformOrigin" Value="0%,0%" />

--- a/src/Stampeded/MainWindow.axaml
+++ b/src/Stampeded/MainWindow.axaml
@@ -11,6 +11,198 @@
   <Window.DataTemplates>
     <local:ViewLocator />
   </Window.DataTemplates>
+  <!-- The menu bar is this app's index of what can be done, so it holds every command a
+       reviewer has - including the ones whose fast path is a pane button or a context menu.
+       The order is the order of the work: pick the change and decide about it, walk it,
+       check it, look at it.
+
+       A NativeMenu rather than a Menu, because a menu bar is not the same object everywhere:
+       macOS puts it in the system bar next to the Apple logo, Windows and Linux draw it inside
+       the window. Declared once here, the NativeMenuBar below decides which of the two it is at
+       runtime and hides itself when the platform took the menu.
+
+       Gestures stay written into the headers instead of becoming a Gesture: the window handles
+       them so they keep working from any pane, and on macOS a Gesture is a real AppKit key
+       equivalent, which fires before the focused text box sees the key - a "v" typed into a
+       comment would mark the file viewed, and Option+Left would navigate instead of moving the
+       caret.
+
+       What a command needs is bound to IsEnabled rather than left to fail: "Close Review"
+       offered with no review open reads as a broken command, not an unavailable one. -->
+  <NativeMenu.Menu>
+    <NativeMenu>
+      <NativeMenuItem Header="_Review">
+        <NativeMenu>
+          <NativeMenuItem Header="Open Repository..." Click="OnOpenRepository" />
+          <NativeMenuItem Header="Open from URL..." Click="OnOpenFromUrl" />
+          <NativeMenuItem Header="Recent Repositories" CommandParameter="RecentMenu">
+            <NativeMenu />
+          </NativeMenuItem>
+          <NativeMenuItemSeparator />
+          <NativeMenuItem Header="Reload Review  ( F5 )" Click="OnReloadReview" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Close Review" Click="OnCloseReview" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItemSeparator />
+          <!-- Reading scope: what the file list below means. Radio rather than three commands,
+               because they are one setting with three values and the reader has to be able to
+               see which one they are in. -->
+          <NativeMenuItem Header="Whole Change" Click="OnExitCommitScope" ToggleType="Radio"
+                          IsChecked="{Binding WholeChangeActive, Mode=OneWay}" IsEnabled="{Binding InScope}" />
+          <NativeMenuItem Header="Commit by Commit" Click="OnEnterCommitScope" ToggleType="Radio"
+                          IsChecked="{Binding InCommitScope, Mode=OneWay}" IsEnabled="{Binding CanEnterCommitScope}"
+                          ToolTip="{Binding CommitScopeTip}" />
+          <NativeMenuItem Header="Since Last Pass" Click="OnSinceLastPass" ToggleType="Radio"
+                          IsChecked="{Binding InSinceLastPassScope, Mode=OneWay}"
+                          IsEnabled="{Binding CanEnterSinceLastPass}"
+                          ToolTip="{Binding SinceLastPassTip}" />
+          <!-- What "last pass" is measured from. A separate group from the scope above: it says
+               where the scope starts, not which scope is on, and choosing one enters it. -->
+          <NativeMenuItem Header="Last Pass Was" IsEnabled="{Binding HasReview}">
+            <NativeMenu>
+              <NativeMenuItem Header="The Last File You Ticked Off" Click="OnPassFromMarked" ToggleType="Radio"
+                              IsChecked="{Binding PassFromMarked, Mode=OneWay}"
+                              ToolTip="{Binding PassFromMarkedTip}"
+                              IsEnabled="{Binding HasPassFromMarked}" />
+              <NativeMenuItem Header="Your Last Submitted Review" Click="OnPassFromSubmitted" ToggleType="Radio"
+                              IsChecked="{Binding PassFromSubmitted, Mode=OneWay}"
+                              ToolTip="{Binding PassFromSubmittedTip}"
+                              IsEnabled="{Binding HasPassFromSubmitted}" />
+              <NativeMenuItem Header="The Last Time You Opened It" Click="OnPassFromOpened" ToggleType="Radio"
+                              IsChecked="{Binding PassFromOpened, Mode=OneWay}"
+                              ToolTip="{Binding PassFromOpenedTip}"
+                              IsEnabled="{Binding HasPassFromOpened}" />
+            </NativeMenu>
+          </NativeMenuItem>
+          <NativeMenuItemSeparator />
+          <NativeMenuItem Header="Mark Viewed + Advance  ( v )" Click="OnToggleViewed" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Comment Here  ( c )" Click="OnCommentAtCaret" IsEnabled="{Binding CanComment}" />
+          <NativeMenuItemSeparator />
+          <!-- Both of these open the Review tab rather than acting: a verdict needs a body and a
+               merge needs a method, and both are typed there. Two entries for one document
+               because they are the two names a reviewer looks for. -->
+          <NativeMenuItem Header="Approve / Request Changes..." Click="OnOpenReviewDocument"
+                          IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Merge Pull Request..." Click="OnOpenReviewDocument"
+                          IsEnabled="{Binding HasPullRequest}" />
+          <NativeMenuItem Header="Rebase PR onto Target Branch" Click="OnRebasePr"
+                          IsEnabled="{Binding HasPullRequest}" />
+          <NativeMenuItemSeparator />
+          <!-- Both are hidden on macOS, where quitting is the app menu's job. -->
+          <NativeMenuItem Header="Exit" CommandParameter="ExitItem" Click="OnExit" />
+        </NativeMenu>
+      </NativeMenuItem>
+      <NativeMenuItem Header="_Navigate">
+        <NativeMenu>
+          <!-- The motions act on the diff in front; with no diff open there is nothing to move
+               through, and that is a state the menu can see only when it opens. -->
+          <NativeMenuItem Header="Next Hunk  ( n / Ctrl+Down )" CommandParameter="NextHunkItem" Click="OnNextHunk" />
+          <NativeMenuItem Header="Previous Hunk  ( p / Ctrl+Up )" CommandParameter="PrevHunkItem" Click="OnPrevHunk" />
+          <NativeMenuItem Header="Next File  ( ] )" Click="OnNextFile" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Previous File  ( [ )" Click="OnPrevFile" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Next Uncovered Added Line  ( u )" CommandParameter="NextUncoveredItem" Click="OnNextUncovered" />
+          <NativeMenuItem Header="Go to...  ( Ctrl+G )" Click="OnGoTo" />
+          <NativeMenuItemSeparator />
+          <NativeMenuItem Header="Next Commit  ( Ctrl+] )" Click="OnNextCommit" IsEnabled="{Binding InCommitScope}" />
+          <NativeMenuItem Header="Previous Commit  ( Ctrl+[ )" Click="OnPreviousCommit"
+                          IsEnabled="{Binding InCommitScope}" />
+          <NativeMenuItemSeparator />
+          <!-- Disabled until semantics are loaded: these are the commands that need a
+               compilation, and the window opens as soon as the diff is read. -->
+          <NativeMenuItem Header="Go to Definition  ( F12 )" Click="OnGoToDefinition"
+                          IsEnabled="{Binding SemanticsReady}" />
+          <NativeMenuItem Header="Find References  ( Shift+F12 )" Click="OnFindReferences"
+                          IsEnabled="{Binding SemanticsReady}" />
+          <NativeMenuItem Header="Highlight Occurrences (click; Esc clears)" Click="OnHighlightOccurrences"
+                          IsEnabled="{Binding SemanticsReady}" />
+          <NativeMenuItem Header="Call Graph from Caret" Click="OnCallGraph" IsEnabled="{Binding SemanticsReady}" />
+          <NativeMenuItemSeparator />
+          <!-- Enabled by what history actually holds, worked out as the menu opens: the extra
+               mouse buttons and Alt+arrow drive the same two commands, and an entry offered with
+               nothing behind it says the reader has run out of history when they have not. -->
+          <NativeMenuItem Header="Back  ( Alt+Left )" CommandParameter="BackItem" Click="OnBack" />
+          <NativeMenuItem Header="Forward  ( Alt+Right )" CommandParameter="ForwardItem" Click="OnForward" />
+          <NativeMenuItemSeparator />
+          <NativeMenuItem Header="Overview / Back to File  ( o )" Click="OnToggleOverview"
+                          IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="History of Selection" CommandParameter="HistoryOfSelectionItem" Click="OnHistoryOfSelection" />
+        </NativeMenu>
+      </NativeMenuItem>
+      <NativeMenuItem Header="_Tools">
+        <NativeMenu>
+          <!-- Each of these shows its pane first: output that lands behind whichever pane is in
+               front is output nobody reads. -->
+          <NativeMenuItem Header="Run Tests" Click="OnRunTests" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Run + Coverage" Click="OnRunTestsWithCoverage" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Run A/B (base vs head)" Click="OnRunTestsAB" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Impacted Test Filter" Click="OnImpactedTestFilter" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItemSeparator />
+          <!-- Filled when the menu opens, from the solutions the checkout actually has. -->
+          <NativeMenuItem Header="Solution to Build" CommandParameter="BuildSolutionMenu" IsEnabled="{Binding HasReview}"
+                          ToolTip="Which solution the test runs and the generated-sources build are for. Automatic prefers a cross-platform filter off Windows, else the repository's largest solution.">
+            <NativeMenu />
+          </NativeMenuItem>
+          <NativeMenuItemSeparator />
+          <NativeMenuItem Header="Run Application" Click="OnRunApplication" />
+          <NativeMenuItem Header="Refresh Checks" Click="OnRefreshChecks" IsEnabled="{Binding HasPullRequest}" />
+          <NativeMenuItemSeparator />
+          <NativeMenuItem Header="Open Head Worktree in VS Code" Click="OnOpenVsCode" IsEnabled="{Binding HasReview}" />
+          <NativeMenuItem Header="Debug Here in VS Code" CommandParameter="DebugHereItem" Click="OnDebugHere" />
+          <NativeMenuItem Header="Open PR on GitHub" Click="OnOpenOnGitHub" IsEnabled="{Binding HasPullRequest}" />
+          <NativeMenuItem Header="Open Affected Fixtures in ILSpy" Click="OnOpenFixtures"
+                          IsEnabled="{Binding HasDecompilerTestCases}" />
+        </NativeMenu>
+      </NativeMenuItem>
+      <NativeMenuItem Header="_View">
+        <NativeMenu>
+          <NativeMenuItem Header="Start Page" Click="OnOpenStart" />
+          <NativeMenuItem Header="Close Document  ( Ctrl+W )" Click="OnCloseDocument" />
+          <NativeMenuItemSeparator />
+          <!-- A way of reading rather than a property of a file: what is set here is what every
+               file opens as, and each is one tab either way. -->
+          <NativeMenuItem Header="Side-by-Side Layout" CommandParameter="SideBySideItem" Click="OnSideBySide"
+                          ToggleType="CheckBox"
+                          ToolTip="Read every change as two panes instead of one interleaved document" />
+          <NativeMenuItem Header="Blame Margin  ( b )" CommandParameter="BlameItem" Click="OnToggleBlame" ToggleType="CheckBox" />
+          <NativeMenuItem Header="Document Tabs in Several Rows" CommandParameter="MultiRowTabsItem"
+                          Click="OnToggleMultiRowTabs" ToggleType="CheckBox" />
+          <!-- Hidden outside a debug build, where the renderer behind it does not exist. -->
+          <NativeMenuItem Header="DEBUG - Pointer Cross-Hair" CommandParameter="PointerCrossHairItem" IsVisible="False"
+                          Click="OnTogglePointerCrossHair" ToggleType="CheckBox"
+                          ToolTip="Draw where the app thinks the pointer is, with the document position it resolves to" />
+          <NativeMenuItemSeparator />
+          <NativeMenuItem Header="Panes">
+            <NativeMenu>
+              <NativeMenuItem Header="Explorer" CommandParameter="Explorer" Click="OnShowPane" />
+              <NativeMenuItem Header="Change Map" CommandParameter="Map" Click="OnShowPane" />
+              <NativeMenuItem Header="Structure" CommandParameter="Structure" Click="OnShowPane" />
+              <NativeMenuItem Header="References" CommandParameter="References" Click="OnShowPane" />
+              <NativeMenuItem Header="Call Graph" CommandParameter="CallGraph" Click="OnShowPane" />
+              <NativeMenuItem Header="Comments" CommandParameter="Comments" Click="OnShowPane" />
+              <NativeMenuItem Header="Checks" CommandParameter="Checks" Click="OnShowPane" />
+              <NativeMenuItem Header="Tests" CommandParameter="Tests" Click="OnShowPane" />
+              <NativeMenuItem Header="Commits" CommandParameter="Commits" Click="OnShowPane" />
+              <NativeMenuItem Header="History" CommandParameter="History" Click="OnShowPane" />
+              <NativeMenuItem Header="Run" CommandParameter="Run" Click="OnShowPane" />
+              <NativeMenuItem Header="Log" CommandParameter="Log" Click="OnShowPane" />
+            </NativeMenu>
+          </NativeMenuItem>
+          <NativeMenuItemSeparator />
+          <NativeMenuItem Header="Zoom In  ( Ctrl++ )" Click="OnZoomIn" />
+          <NativeMenuItem Header="Zoom Out  ( Ctrl+- )" Click="OnZoomOut" />
+          <NativeMenuItem Header="Reset Zoom  ( Ctrl+0 )" Click="OnZoomReset" />
+        </NativeMenu>
+      </NativeMenuItem>
+      <NativeMenuItem Header="_Help">
+        <NativeMenu>
+          <NativeMenuItem Header="Keyboard Shortcuts" Click="OnKeyboardShortcuts" />
+          <NativeMenuItemSeparator />
+          <!-- What the tool did and why it is slow: the questions Help is opened with. -->
+          <NativeMenuItem Header="Log Pane" CommandParameter="Log" Click="OnShowPane" />
+          <NativeMenuItem Header="Semantic Load Log" Click="OnShowSemanticLog" />
+          <NativeMenuItem Header="Prune Worktree Cache" Click="OnPruneWorktrees" />
+        </NativeMenu>
+      </NativeMenuItem>
+    </NativeMenu>
+  </NativeMenu.Menu>
   <!-- LayoutTransformControl rather than a RenderTransform: this one re-runs layout at the
        new scale, so text is laid out and rendered at that size instead of a fixed layout
        being magnified. -->
@@ -19,174 +211,9 @@
       <ScaleTransform ScaleX="{Binding Zoom}" ScaleY="{Binding Zoom}" />
     </LayoutTransformControl.LayoutTransform>
   <DockPanel>
-    <!-- The menu bar is this app's index of what can be done, so it holds every command a
-         reviewer has - including the ones whose fast path is a pane button or a context menu.
-         The order is the order of the work: pick the change and decide about it, walk it,
-         check it, look at it.
-
-         Single-letter gestures stay written into the headers instead of becoming an
-         InputGesture: the window handles them so they keep working from any pane, and a menu
-         gesture would swallow a "v" typed into a comment. Real modifier gestures are real
-         InputGestures.
-
-         What a command needs is bound to IsEnabled rather than left to fail: "Close Review"
-         offered with no review open reads as a broken command, not an unavailable one. -->
-    <Menu DockPanel.Dock="Top">
-      <MenuItem Header="_Review" SubmenuOpened="OnMenuOpening">
-        <MenuItem Header="Open Repository..." Click="OnOpenRepository" />
-        <MenuItem Header="Open from URL..." Click="OnOpenFromUrl" />
-        <MenuItem Header="Recent Repositories" x:Name="RecentMenu" ItemsSource="{Binding Recent}" />
-        <Separator />
-        <MenuItem Header="Reload Review  ( F5 )" Click="OnReloadReview" IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Close Review" Click="OnCloseReview" IsEnabled="{Binding HasReview}" />
-        <Separator />
-        <!-- Reading scope: what the file list below means. Radio rather than three commands,
-             because they are one setting with three values and the reader has to be able to
-             see which one they are in. -->
-        <MenuItem Header="Whole Change" Click="OnExitCommitScope" ToggleType="Radio" GroupName="scope"
-                  IsChecked="{Binding WholeChangeActive, Mode=OneWay}" IsEnabled="{Binding InScope}" />
-        <MenuItem Header="Commit by Commit" Click="OnEnterCommitScope" ToggleType="Radio" GroupName="scope"
-                  IsChecked="{Binding InCommitScope, Mode=OneWay}" IsEnabled="{Binding CanEnterCommitScope}"
-                  ToolTip.ShowOnDisabled="True" ToolTip.Tip="{Binding CommitScopeTip}" />
-        <MenuItem Header="Since Last Pass" Click="OnSinceLastPass" ToggleType="Radio" GroupName="scope"
-                  IsChecked="{Binding InSinceLastPassScope, Mode=OneWay}"
-                  IsEnabled="{Binding CanEnterSinceLastPass}"
-                  ToolTip.ShowOnDisabled="True" ToolTip.Tip="{Binding SinceLastPassTip}" />
-        <!-- What "last pass" is measured from. A separate group from the scope above: it says
-             where the scope starts, not which scope is on, and choosing one enters it. -->
-        <MenuItem Header="Last Pass Was" IsEnabled="{Binding HasReview}">
-          <MenuItem Header="The Last File You Ticked Off" Click="OnPassFromMarked" ToggleType="Radio"
-                    GroupName="passbaseline" IsChecked="{Binding PassFromMarked, Mode=OneWay}"
-                    ToolTip.ShowOnDisabled="True" ToolTip.Tip="{Binding PassFromMarkedTip}"
-                    IsEnabled="{Binding HasPassFromMarked}" />
-          <MenuItem Header="Your Last Submitted Review" Click="OnPassFromSubmitted" ToggleType="Radio"
-                    GroupName="passbaseline" IsChecked="{Binding PassFromSubmitted, Mode=OneWay}"
-                    ToolTip.ShowOnDisabled="True" ToolTip.Tip="{Binding PassFromSubmittedTip}"
-                    IsEnabled="{Binding HasPassFromSubmitted}" />
-          <MenuItem Header="The Last Time You Opened It" Click="OnPassFromOpened" ToggleType="Radio"
-                    GroupName="passbaseline" IsChecked="{Binding PassFromOpened, Mode=OneWay}"
-                    ToolTip.ShowOnDisabled="True" ToolTip.Tip="{Binding PassFromOpenedTip}"
-                    IsEnabled="{Binding HasPassFromOpened}" />
-        </MenuItem>
-        <Separator />
-        <MenuItem Header="Mark Viewed + Advance  ( v )" Click="OnToggleViewed" IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Comment Here  ( c )" Click="OnCommentAtCaret" IsEnabled="{Binding CanComment}" />
-        <Separator />
-        <!-- Both of these open the Review tab rather than acting: a verdict needs a body and a
-             merge needs a method, and both are typed there. Two entries for one document
-             because they are the two names a reviewer looks for. -->
-        <MenuItem Header="Approve / Request Changes..." Click="OnOpenReviewDocument"
-                  IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Merge Pull Request..." Click="OnOpenReviewDocument"
-                  IsEnabled="{Binding HasPullRequest}" />
-        <MenuItem Header="Rebase PR onto Target Branch" Click="OnRebasePr"
-                  IsEnabled="{Binding HasPullRequest}" />
-        <Separator />
-        <MenuItem Header="Exit" Click="OnExit" />
-      </MenuItem>
-      <MenuItem Header="_Navigate" SubmenuOpened="OnMenuOpening">
-        <!-- The motions act on the diff in front; with no diff open there is nothing to move
-             through, and that is a state the menu can see only when it opens. -->
-        <MenuItem Header="Next Hunk  ( n / Ctrl+Down )" x:Name="NextHunkItem" Click="OnNextHunk" />
-        <MenuItem Header="Previous Hunk  ( p / Ctrl+Up )" x:Name="PrevHunkItem" Click="OnPrevHunk" />
-        <MenuItem Header="Next File  ( ] )" Click="OnNextFile" IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Previous File  ( [ )" Click="OnPrevFile" IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Next Uncovered Added Line  ( u )" x:Name="NextUncoveredItem" Click="OnNextUncovered" />
-        <MenuItem Header="Go to...  ( Ctrl+G )" Click="OnGoTo" />
-        <Separator />
-        <MenuItem Header="Next Commit  ( Ctrl+] )" Click="OnNextCommit" IsEnabled="{Binding InCommitScope}" />
-        <MenuItem Header="Previous Commit  ( Ctrl+[ )" Click="OnPreviousCommit"
-                  IsEnabled="{Binding InCommitScope}" />
-        <Separator />
-        <!-- Disabled until semantics are loaded: these are the commands that need a
-             compilation, and the window opens as soon as the diff is read. -->
-        <MenuItem Header="Go to Definition" InputGesture="F12" Click="OnGoToDefinition"
-                  IsEnabled="{Binding SemanticsReady}" />
-        <MenuItem Header="Find References" InputGesture="Shift+F12" Click="OnFindReferences"
-                  IsEnabled="{Binding SemanticsReady}" />
-        <MenuItem Header="Highlight Occurrences (click; Esc clears)" Click="OnHighlightOccurrences"
-                  IsEnabled="{Binding SemanticsReady}" />
-        <MenuItem Header="Call Graph from Caret" Click="OnCallGraph" IsEnabled="{Binding SemanticsReady}" />
-        <Separator />
-        <!-- Enabled by what history actually holds, worked out as the menu opens: the extra
-             mouse buttons and Alt+arrow drive the same two commands, and an entry offered with
-             nothing behind it says the reader has run out of history when they have not. -->
-        <MenuItem Header="Back" InputGesture="Alt+Left" Click="OnBack" x:Name="BackItem" />
-        <MenuItem Header="Forward" InputGesture="Alt+Right" Click="OnForward" x:Name="ForwardItem" />
-        <Separator />
-        <MenuItem Header="Overview / Back to File  ( o )" Click="OnToggleOverview"
-                  IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="History of Selection" x:Name="HistoryOfSelectionItem" Click="OnHistoryOfSelection" />
-      </MenuItem>
-      <MenuItem Header="_Tools" SubmenuOpened="OnMenuOpening">
-        <!-- Each of these shows its pane first: output that lands behind whichever pane is in
-             front is output nobody reads. -->
-        <MenuItem Header="Run Tests" Click="OnRunTests" IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Run + Coverage" Click="OnRunTestsWithCoverage" IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Run A/B (base vs head)" Click="OnRunTestsAB" IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Impacted Test Filter" Click="OnImpactedTestFilter" IsEnabled="{Binding HasReview}" />
-        <Separator />
-        <!-- Filled when the menu opens, from the solutions the checkout actually has. -->
-        <MenuItem Header="Solution to Build" x:Name="BuildSolutionMenu" IsEnabled="{Binding HasReview}"
-                  ToolTip.Tip="Which solution the test runs and the generated-sources build are for. Automatic prefers a cross-platform filter off Windows, else the repository's largest solution." />
-        <Separator />
-        <MenuItem Header="Run Application" Click="OnRunApplication" />
-        <MenuItem Header="Refresh Checks" Click="OnRefreshChecks" IsEnabled="{Binding HasPullRequest}" />
-        <Separator />
-        <MenuItem Header="Open Head Worktree in VS Code" Click="OnOpenVsCode" IsEnabled="{Binding HasReview}" />
-        <MenuItem Header="Debug Here in VS Code" x:Name="DebugHereItem" Click="OnDebugHere" />
-        <MenuItem Header="Open PR on GitHub" Click="OnOpenOnGitHub" IsEnabled="{Binding HasPullRequest}" />
-        <MenuItem Header="Open Affected Fixtures in ILSpy" Click="OnOpenFixtures"
-                  IsEnabled="{Binding HasDecompilerTestCases}" />
-      </MenuItem>
-      <MenuItem Header="_View" SubmenuOpened="OnMenuOpening">
-        <MenuItem Header="Start Page" Click="OnOpenStart" />
-        <MenuItem Header="Close Document  ( Ctrl+W )" Click="OnCloseDocument" />
-        <Separator />
-        <!-- A way of reading rather than a property of a file: what is set here is what every
-             file opens as, and each is one tab either way. -->
-        <MenuItem Header="Side-by-Side Layout" x:Name="SideBySideItem" Click="OnSideBySide"
-                  ToggleType="CheckBox"
-                  ToolTip.Tip="Read every change as two panes instead of one interleaved document" />
-        <MenuItem Header="Blame Margin  ( b )" x:Name="BlameItem" Click="OnToggleBlame" ToggleType="CheckBox" />
-        <MenuItem Header="Document Tabs in Several Rows" x:Name="MultiRowTabsItem"
-                  Click="OnToggleMultiRowTabs" ToggleType="CheckBox" />
-        <!-- Hidden outside a debug build, where the renderer behind it does not exist. -->
-        <MenuItem Header="DEBUG - Pointer Cross-Hair" x:Name="PointerCrossHairItem" IsVisible="False"
-                  Click="OnTogglePointerCrossHair" ToggleType="CheckBox"
-                  ToolTip.Tip="Draw where the app thinks the pointer is, with the document position it resolves to" />
-        <Separator />
-        <MenuItem Header="Panes">
-          <MenuItem Header="Explorer" Tag="Explorer" Click="OnShowPane" />
-          <MenuItem Header="Change Map" Tag="Map" Click="OnShowPane" />
-          <MenuItem Header="Structure" Tag="Structure" Click="OnShowPane" />
-          <MenuItem Header="References" Tag="References" Click="OnShowPane" />
-          <MenuItem Header="Call Graph" Tag="CallGraph" Click="OnShowPane" />
-          <MenuItem Header="Comments" Tag="Comments" Click="OnShowPane" />
-          <MenuItem Header="Checks" Tag="Checks" Click="OnShowPane" />
-          <MenuItem Header="Tests" Tag="Tests" Click="OnShowPane" />
-          <MenuItem Header="Commits" Tag="Commits" Click="OnShowPane" />
-          <MenuItem Header="History" Tag="History" Click="OnShowPane" />
-          <MenuItem Header="Run" Tag="Run" Click="OnShowPane" />
-          <MenuItem Header="Log" Tag="Log" Click="OnShowPane" />
-        </MenuItem>
-        <Separator />
-        <!-- The gestures live in the headers, not as InputGesture: the window handles them so
-             they keep working while a text box has focus, and a menu gesture would take them
-             first. "Ctrl+Plus" is also not a gesture Avalonia can parse - Plus is no Key. -->
-        <MenuItem Header="Zoom In  ( Ctrl++ )" Click="OnZoomIn" />
-        <MenuItem Header="Zoom Out  ( Ctrl+- )" Click="OnZoomOut" />
-        <MenuItem Header="Reset Zoom  ( Ctrl+0 )" Click="OnZoomReset" />
-      </MenuItem>
-      <MenuItem Header="_Help">
-        <MenuItem Header="Keyboard Shortcuts" Click="OnKeyboardShortcuts" />
-        <Separator />
-        <!-- What the tool did and why it is slow: the questions Help is opened with. -->
-        <MenuItem Header="Log Pane" Tag="Log" Click="OnShowPane" />
-        <MenuItem Header="Semantic Load Log" Click="OnShowSemanticLog" />
-        <MenuItem Header="Prune Worktree Cache" Click="OnPruneWorktrees" />
-      </MenuItem>
-    </Menu>
+    <!-- Empty and zero-height on macOS, where the platform took the menu; the bar the menu is
+         drawn in on Windows and Linux. -->
+    <NativeMenuBar DockPanel.Dock="Top" />
     <Border DockPanel.Dock="Bottom" Padding="8,3" IsVisible="{Binding Busy.IsBusy}">
       <StackPanel Orientation="Horizontal" Spacing="8">
         <TextBlock Text="{Binding Busy.SpinnerFrame}" FontFamily="monospace" />

--- a/src/Stampeded/MainWindow.axaml.cs
+++ b/src/Stampeded/MainWindow.axaml.cs
@@ -9,13 +9,45 @@ namespace Stampeded;
 
 public partial class MainWindow : Window
 {
+	// The menu items this file has to reach: the ones whose state is not a binding away, and the
+	// two whose submenu is built when it opens. A menu item is a model object rather than a
+	// control, so it cannot carry an x:Name and Avalonia generates no field for one - what names
+	// them instead is the key each carries as its CommandParameter.
+	readonly NativeMenuItem recentMenu, buildSolutionMenu, exitItem,
+		nextHunkItem, prevHunkItem, nextUncoveredItem, historyOfSelectionItem,
+		backItem, forwardItem,
+		sideBySideItem, blameItem, multiRowTabsItem, pointerCrossHairItem, debugHereItem;
+
 	public MainWindow()
 	{
 		InitializeComponent();
+		var menu = NativeMenu.GetMenu(this);
+		NativeMenuItem Named(string key) => FindMenuItem(menu, i => key.Equals(i.CommandParameter))
+			?? throw new InvalidOperationException($"no menu item is keyed {key}");
+		recentMenu = Named("RecentMenu");
+		buildSolutionMenu = Named("BuildSolutionMenu");
+		exitItem = Named("ExitItem");
+		nextHunkItem = Named("NextHunkItem");
+		prevHunkItem = Named("PrevHunkItem");
+		nextUncoveredItem = Named("NextUncoveredItem");
+		historyOfSelectionItem = Named("HistoryOfSelectionItem");
+		backItem = Named("BackItem");
+		forwardItem = Named("ForwardItem");
+		sideBySideItem = Named("SideBySideItem");
+		blameItem = Named("BlameItem");
+		multiRowTabsItem = Named("MultiRowTabsItem");
+		pointerCrossHairItem = Named("PointerCrossHairItem");
+		debugHereItem = Named("DebugHereItem");
 		WindowPlacement.Attach(this);
 		DataContext = new MainViewModel();
 		ScreenshotWatcher.Attach(this);
-		RecentMenu.AddHandler(MenuItem.ClickEvent, OnRecentRepoClick);
+		// A menu about to be shown is the only moment its per-document state is not stale, and
+		// each platform says so differently: the exported macOS menu asks the model for an
+		// update, while the bar drawn inside the window raises a routed event from the item that
+		// opened. Both lead to the same refresh.
+		foreach (var top in menu!.Items.OfType<NativeMenuItem>())
+			top.Menu!.NeedsUpdate += OnMenuOpening;
+		AddHandler(MenuItem.SubmenuOpenedEvent, OnSubmenuOpened, RoutingStrategies.Bubble);
 		// The extra mouse buttons, the way every browser and IDE reads them. The press is
 		// taken so nothing under the pointer acts on it, and the release does the navigating -
 		// handledEventsToo because the editors handle pointer events for their own gestures
@@ -23,6 +55,17 @@ public partial class MainWindow : Window
 		AddHandler(PointerPressedEvent, OnNavigationPointerPressed, RoutingStrategies.Tunnel);
 		AddHandler(PointerReleasedEvent, OnNavigationPointerReleased,
 			RoutingStrategies.Bubble, handledEventsToo: true);
+		// Quitting is the app menu's job on macOS, where every application has that item in the
+		// same place; a second one under Review would be the odd one out. Taken out of the model
+		// rather than hidden, so the separator that introduced it goes with it instead of ending
+		// the menu on a rule with nothing under it.
+		if (OperatingSystem.IsMacOS() && exitItem.Parent is { } review)
+		{
+			int index = review.Items.IndexOf(exitItem);
+			review.Items.RemoveAt(index);
+			if (index > 0 && review.Items[index - 1] is NativeMenuItemSeparator separator)
+				review.Items.Remove(separator);
+		}
 	}
 
 	void OnNavigationPointerPressed(object? sender, PointerPressedEventArgs e)
@@ -52,13 +95,36 @@ public partial class MainWindow : Window
 		e.Handled = true;
 	}
 
+	/// <summary>The in-window menu bar's stand-in for a menu that is about to be shown. Only the
+	/// top row counts: the submenus this rebuilds are nested ones, and rebuilding a submenu while
+	/// it is opening takes away what the pointer is already over.</summary>
+	void OnSubmenuOpened(object? s, RoutedEventArgs e)
+	{
+		if (e.Source is MenuItem { Parent: Menu })
+			OnMenuOpening(s, e);
+	}
+
+	/// <summary>The first item anywhere under a menu that answers to the predicate: how an item is
+	/// picked out of a menu that has no controls in it to look up.</summary>
+	internal static NativeMenuItem? FindMenuItem(NativeMenu? menu, Func<NativeMenuItem, bool> match)
+	{
+		foreach (var item in menu?.Items.OfType<NativeMenuItem>() ?? Enumerable.Empty<NativeMenuItem>())
+		{
+			if (match(item))
+				return item;
+			if (FindMenuItem(item.Menu, match) is { } nested)
+				return nested;
+		}
+		return null;
+	}
+
 	MainViewModel? Vm => DataContext as MainViewModel;
 
-	void OnZoomIn(object? s, RoutedEventArgs e) => Vm?.ZoomIn();
+	void OnZoomIn(object? s, EventArgs e) => Vm?.ZoomIn();
 
-	void OnZoomOut(object? s, RoutedEventArgs e) => Vm?.ZoomOut();
+	void OnZoomOut(object? s, EventArgs e) => Vm?.ZoomOut();
 
-	void OnZoomReset(object? s, RoutedEventArgs e) => Vm?.ZoomReset();
+	void OnZoomReset(object? s, EventArgs e) => Vm?.ZoomReset();
 
 	/// <summary>
 	/// The zoom gestures. They are handled here rather than as InputGesture on the menu items
@@ -160,13 +226,7 @@ public partial class MainWindow : Window
 		e.Handled = true;
 	}
 
-	void OnRecentRepoClick(object? sender, RoutedEventArgs e)
-	{
-		if (e.Source is MenuItem { Header: string path } item && item != RecentMenu)
-			App.OpenRepositoryAsync(path).HandleExceptions();
-	}
-
-	void OnOpenRepository(object? s, RoutedEventArgs e) => PickRepositoryAsync().HandleExceptions();
+	void OnOpenRepository(object? s, EventArgs e) => PickRepositoryAsync().HandleExceptions();
 
 	async Task PickRepositoryAsync()
 	{
@@ -178,7 +238,7 @@ public partial class MainWindow : Window
 			await App.OpenRepositoryAsync(picks[0].Path.LocalPath);
 	}
 
-	void OnGoTo(object? s, RoutedEventArgs e) => GoToAsync().HandleExceptions();
+	void OnGoTo(object? s, EventArgs e) => GoToAsync().HandleExceptions();
 
 	/// <summary>The one dialog for both halves of "go to": which file, and where in it. A file
 	/// without a line opens it where it was left; a line without a file moves within the
@@ -199,7 +259,7 @@ public partial class MainWindow : Window
 		await workspace.NavigateToFileLineAsync(path, target.Line ?? 1, oldSide: false, record: true);
 	}
 
-	void OnOpenFromUrl(object? s, RoutedEventArgs e) => PromptUrlAsync().HandleExceptions();
+	void OnOpenFromUrl(object? s, EventArgs e) => PromptUrlAsync().HandleExceptions();
 
 	async Task PromptUrlAsync()
 	{
@@ -219,27 +279,42 @@ public partial class MainWindow : Window
 	/// what this layout has not got.</summary>
 	static bool Has(ReviewCommands command) => View?.Supported.HasFlag(command) == true;
 
-	void OnNextHunk(object? s, RoutedEventArgs e) => View?.JumpToHunkCommand(1);
-	void OnPrevHunk(object? s, RoutedEventArgs e) => View?.JumpToHunkCommand(-1);
-	void OnNextFile(object? s, RoutedEventArgs e) => App.Workspace?.OpenAdjacentFileAsync(1).HandleExceptions();
-	void OnPrevFile(object? s, RoutedEventArgs e) => App.Workspace?.OpenAdjacentFileAsync(-1).HandleExceptions();
-	void OnToggleViewed(object? s, RoutedEventArgs e) => App.Workspace?.ToggleViewedAndAdvanceAsync().HandleExceptions();
-	void OnToggleOverview(object? s, RoutedEventArgs e) => App.Workspace?.ToggleOverviewAsync().HandleExceptions();
-	void OnToggleBlame(object? s, RoutedEventArgs e) => View?.ToggleBlameCommand();
-	void OnCommentAtCaret(object? s, RoutedEventArgs e) => View?.CommentAtCaretCommand();
-	void OnGoToDefinition(object? s, RoutedEventArgs e) => View?.GoToDefinitionCommand();
-	void OnFindReferences(object? s, RoutedEventArgs e) => View?.FindReferencesCommand();
-	void OnHighlightOccurrences(object? s, RoutedEventArgs e) => View?.HighlightOccurrencesCommand();
-	void OnSideBySide(object? s, RoutedEventArgs e)
+	void OnNextHunk(object? s, EventArgs e) => View?.JumpToHunkCommand(1);
+	void OnPrevHunk(object? s, EventArgs e) => View?.JumpToHunkCommand(-1);
+	void OnNextFile(object? s, EventArgs e) => App.Workspace?.OpenAdjacentFileAsync(1).HandleExceptions();
+	void OnPrevFile(object? s, EventArgs e) => App.Workspace?.OpenAdjacentFileAsync(-1).HandleExceptions();
+	void OnToggleViewed(object? s, EventArgs e) => App.Workspace?.ToggleViewedAndAdvanceAsync().HandleExceptions();
+	void OnToggleOverview(object? s, EventArgs e) => App.Workspace?.ToggleOverviewAsync().HandleExceptions();
+	void OnToggleBlame(object? s, EventArgs e) => View?.ToggleBlameCommand();
+	void OnCommentAtCaret(object? s, EventArgs e) => View?.CommentAtCaretCommand();
+	void OnGoToDefinition(object? s, EventArgs e) => View?.GoToDefinitionCommand();
+	void OnFindReferences(object? s, EventArgs e) => View?.FindReferencesCommand();
+	void OnHighlightOccurrences(object? s, EventArgs e) => View?.HighlightOccurrencesCommand();
+	void OnSideBySide(object? s, EventArgs e)
 		=> App.Workspace?.SetDiffLayoutAsync(!DiffLayoutPreference.SideBySide).HandleExceptions();
-	void OnCloseDocument(object? s, RoutedEventArgs e) => App.Workspace?.CloseActiveDocument();
+	void OnCloseDocument(object? s, EventArgs e) => App.Workspace?.CloseActiveDocument();
 
-	void OnShowPane(object? s, RoutedEventArgs e)
+	void OnShowPane(object? s, EventArgs e)
 	{
-		if (s is MenuItem { Tag: string id })
+		if (s is NativeMenuItem { CommandParameter: string id })
 			App.Workspace?.Factory?.ShowPane(id);
 	}
-	void OnPruneWorktrees(object? s, RoutedEventArgs e) => App.Workspace?.PruneWorktreeCacheAsync().HandleExceptions();
+	void OnPruneWorktrees(object? s, EventArgs e) => App.Workspace?.PruneWorktreeCacheAsync().HandleExceptions();
+
+	/// <summary>The repositories opened before. A menu item has no ItemsSource to bind the list
+	/// to, so it is built when the menu opens - which is also the moment it can have grown since
+	/// the window was created.</summary>
+	void FillRecentMenu()
+	{
+		var items = recentMenu.Menu!.Items;
+		items.Clear();
+		foreach (string path in Vm?.Recent ?? Enumerable.Empty<string>())
+		{
+			var item = new NativeMenuItem { Header = path };
+			item.Click += (_, _) => App.OpenRepositoryAsync(path).HandleExceptions();
+			items.Add(item);
+		}
+	}
 
 	/// <summary>
 	/// Lists the checkout's solutions so one can be named for builds, with what the automatic
@@ -248,22 +323,22 @@ public partial class MainWindow : Window
 	/// </summary>
 	void FillBuildSolutionMenu()
 	{
-		BuildSolutionMenu.Items.Clear();
+		var items = buildSolutionMenu.Menu!.Items;
+		items.Clear();
 		if (App.Workspace is not { } workspace)
 			return;
 		string root = workspace.RepoPath;
 		string? chosen = BuildSolutionPreference.For(root);
 		string automatic = Core.Infra.SolutionTarget.ForRoot(root) ?? "nothing to build";
-		BuildSolutionMenu.Items.Add(Option($"Automatic  ({automatic})", null, chosen is null));
+		items.Add(Option($"Automatic  ({automatic})", null, chosen is null));
 		foreach (string solution in Core.Infra.SolutionTarget.Candidates(root))
-			BuildSolutionMenu.Items.Add(Option(solution, solution, solution == chosen));
+			items.Add(Option(solution, solution, solution == chosen));
 
-		MenuItem Option(string header, string? solution, bool current)
+		NativeMenuItem Option(string header, string? solution, bool current)
 		{
-			var item = new MenuItem {
+			var item = new NativeMenuItem {
 				Header = header,
 				ToggleType = MenuItemToggleType.Radio,
-				GroupName = "build-solution",
 				IsChecked = current,
 			};
 			item.Click += (_, _) => {
@@ -280,24 +355,24 @@ public partial class MainWindow : Window
 		}
 	}
 
-	void OnRebasePr(object? s, RoutedEventArgs e) => App.Workspace?.RebaseCurrentPrOnTargetAsync().HandleExceptions();
+	void OnRebasePr(object? s, EventArgs e) => App.Workspace?.RebaseCurrentPrOnTargetAsync().HandleExceptions();
 
 	// The overview page's commands, so they are reachable without going back to that tab.
-	void OnEnterCommitScope(object? s, RoutedEventArgs e) => App.Workspace?.Scopes.EnterCommitAsync().HandleExceptions();
-	void OnNextCommit(object? s, RoutedEventArgs e) => App.Workspace?.Scopes.StepCommitAsync(1).HandleExceptions();
-	void OnPreviousCommit(object? s, RoutedEventArgs e) => App.Workspace?.Scopes.StepCommitAsync(-1).HandleExceptions();
-	void OnExitCommitScope(object? s, RoutedEventArgs e) => App.Workspace?.Scopes.ExitAsync().HandleExceptions();
-	void OnOpenVsCode(object? s, RoutedEventArgs e) => App.Workspace?.OpenInVsCodeAsync(oldSide: false).HandleExceptions();
-	void OnOpenFixtures(object? s, RoutedEventArgs e) => App.Workspace?.OpenAffectedFixturesInILSpyAsync().HandleExceptions();
+	void OnEnterCommitScope(object? s, EventArgs e) => App.Workspace?.Scopes.EnterCommitAsync().HandleExceptions();
+	void OnNextCommit(object? s, EventArgs e) => App.Workspace?.Scopes.StepCommitAsync(1).HandleExceptions();
+	void OnPreviousCommit(object? s, EventArgs e) => App.Workspace?.Scopes.StepCommitAsync(-1).HandleExceptions();
+	void OnExitCommitScope(object? s, EventArgs e) => App.Workspace?.Scopes.ExitAsync().HandleExceptions();
+	void OnOpenVsCode(object? s, EventArgs e) => App.Workspace?.OpenInVsCodeAsync(oldSide: false).HandleExceptions();
+	void OnOpenFixtures(object? s, EventArgs e) => App.Workspace?.OpenAffectedFixturesInILSpyAsync().HandleExceptions();
 
-	void OnSinceLastPass(object? s, RoutedEventArgs e) => App.Workspace?.Scopes.EnterSinceLastPassAsync().HandleExceptions();
+	void OnSinceLastPass(object? s, EventArgs e) => App.Workspace?.Scopes.EnterSinceLastPassAsync().HandleExceptions();
 
 	// Choosing where a pass starts also reads from there: the choice is only ever made to see
 	// that scope, and leaving the reader to press the scope entry afterwards is a second step
 	// for one intention.
-	void OnPassFromMarked(object? s, RoutedEventArgs e) => UsePassBaseline(PassBaselineKind.MarkedViewed);
-	void OnPassFromSubmitted(object? s, RoutedEventArgs e) => UsePassBaseline(PassBaselineKind.SubmittedReview);
-	void OnPassFromOpened(object? s, RoutedEventArgs e) => UsePassBaseline(PassBaselineKind.Opened);
+	void OnPassFromMarked(object? s, EventArgs e) => UsePassBaseline(PassBaselineKind.MarkedViewed);
+	void OnPassFromSubmitted(object? s, EventArgs e) => UsePassBaseline(PassBaselineKind.SubmittedReview);
+	void OnPassFromOpened(object? s, EventArgs e) => UsePassBaseline(PassBaselineKind.Opened);
 
 	static void UsePassBaseline(PassBaselineKind kind)
 	{
@@ -307,23 +382,23 @@ public partial class MainWindow : Window
 		workspace.Scopes.EnterSinceLastPassAsync().HandleExceptions();
 	}
 
-	void OnOpenStart(object? s, RoutedEventArgs e) => App.Workspace?.OpenStart();
+	void OnOpenStart(object? s, EventArgs e) => App.Workspace?.OpenStart();
 
-	void OnCloseReview(object? s, RoutedEventArgs e) => App.Workspace?.CloseReviewAsync().HandleExceptions();
+	void OnCloseReview(object? s, EventArgs e) => App.Workspace?.CloseReviewAsync().HandleExceptions();
 
-	void OnReloadReview(object? s, RoutedEventArgs e) => App.Workspace?.ReloadReviewAsync().HandleExceptions();
+	void OnReloadReview(object? s, EventArgs e) => App.Workspace?.ReloadReviewAsync().HandleExceptions();
 
-	void OnOpenOverview(object? s, RoutedEventArgs e) => App.Workspace?.OpenOverview();
+	void OnOpenOverview(object? s, EventArgs e) => App.Workspace?.OpenOverview();
 
 	void OnContinueFromPrepare(object? s, RoutedEventArgs e) => App.Workspace?.StartPage?.ContinueNow();
 
-	void OnOpenOnGitHub(object? s, RoutedEventArgs e)
+	void OnOpenOnGitHub(object? s, EventArgs e)
 	{
 		if (App.Workspace is { CurrentPr: { } pr } ws)
 			ws.OpenOnGitHubAsync(pr.Number).HandleExceptions();
 	}
 
-	void OnShowSemanticLog(object? s, RoutedEventArgs e)
+	void OnShowSemanticLog(object? s, EventArgs e)
 	{
 		if (App.Workspace is not { } ws)
 			return;
@@ -331,27 +406,27 @@ public partial class MainWindow : Window
 			$"== base workspace ({ws.BaseSemantics?.State.ToString() ?? "none"}) ==\n{ws.BaseSemantics?.LoadLog}";
 		ws.OpenTextDocument("semlog", "Semantic load log", log);
 	}
-	void OnBack(object? s, RoutedEventArgs e) => App.Workspace?.GoBackAsync().HandleExceptions();
-	void OnForward(object? s, RoutedEventArgs e) => App.Workspace?.GoForwardAsync().HandleExceptions();
+	void OnBack(object? s, EventArgs e) => App.Workspace?.GoBackAsync().HandleExceptions();
+	void OnForward(object? s, EventArgs e) => App.Workspace?.GoForwardAsync().HandleExceptions();
 
-	void OnNextUncovered(object? s, RoutedEventArgs e) => View?.JumpToUncoveredCommand();
+	void OnNextUncovered(object? s, EventArgs e) => View?.JumpToUncoveredCommand();
 
-	void OnCallGraph(object? s, RoutedEventArgs e) => View?.ShowCallGraphCommand();
+	void OnCallGraph(object? s, EventArgs e) => View?.ShowCallGraphCommand();
 
-	void OnHistoryOfSelection(object? s, RoutedEventArgs e) => View?.HistoryOfSelectionCommand();
+	void OnHistoryOfSelection(object? s, EventArgs e) => View?.HistoryOfSelectionCommand();
 
-	void OnDebugHere(object? s, RoutedEventArgs e) => View?.DebugHereCommand();
+	void OnDebugHere(object? s, EventArgs e) => View?.DebugHereCommand();
 
-	void OnOpenReviewDocument(object? s, RoutedEventArgs e) => App.Workspace?.OpenReviewDocument();
+	void OnOpenReviewDocument(object? s, EventArgs e) => App.Workspace?.OpenReviewDocument();
 
-	void OnExit(object? s, RoutedEventArgs e) => Close();
+	void OnExit(object? s, EventArgs e) => Close();
 
-	void OnToggleMultiRowTabs(object? s, RoutedEventArgs e) => TabRowsPreference.Set(!TabRowsPreference.MultiRow);
+	void OnToggleMultiRowTabs(object? s, EventArgs e) => TabRowsPreference.Set(!TabRowsPreference.MultiRow);
 
 	/// <summary>Switches the pointer cross-hair on every open view. A debug build only: what it
 	/// draws is a developer's answer to "where does the app think the pointer is", which is the
 	/// first question whenever a tooltip or popup opens somewhere unexpected.</summary>
-	void OnTogglePointerCrossHair(object? s, RoutedEventArgs e)
+	void OnTogglePointerCrossHair(object? s, EventArgs e)
 	{
 #if DEBUG
 		Editor.PointerCrossHairRenderer.IsEnabled = !Editor.PointerCrossHairRenderer.IsEnabled;
@@ -360,24 +435,24 @@ public partial class MainWindow : Window
 #endif
 	}
 
-	void OnKeyboardShortcuts(object? s, RoutedEventArgs e)
+	void OnKeyboardShortcuts(object? s, EventArgs e)
 		=> App.Workspace?.OpenTextDocument("keys", "Keyboard shortcuts", KeyboardShortcuts.Text);
 
 	// The pane commands: the pane comes forward first, because a run whose output lands behind
 	// whichever pane happens to be in front is a run nobody sees.
-	void OnRunTests(object? s, RoutedEventArgs e) => Pane<Panes.TestsPaneViewModel>("Tests")?.Run();
+	void OnRunTests(object? s, EventArgs e) => Pane<Panes.TestsPaneViewModel>("Tests")?.Run();
 
-	void OnRunTestsWithCoverage(object? s, RoutedEventArgs e)
+	void OnRunTestsWithCoverage(object? s, EventArgs e)
 		=> Pane<Panes.TestsPaneViewModel>("Tests")?.RunWithCoverage();
 
-	void OnRunTestsAB(object? s, RoutedEventArgs e) => Pane<Panes.TestsPaneViewModel>("Tests")?.RunAB();
+	void OnRunTestsAB(object? s, EventArgs e) => Pane<Panes.TestsPaneViewModel>("Tests")?.RunAB();
 
-	void OnImpactedTestFilter(object? s, RoutedEventArgs e)
+	void OnImpactedTestFilter(object? s, EventArgs e)
 		=> Pane<Panes.TestsPaneViewModel>("Tests")?.ApplyImpactedFilter();
 
-	void OnRunApplication(object? s, RoutedEventArgs e) => Pane<Panes.RunPaneViewModel>("Run")?.Run();
+	void OnRunApplication(object? s, EventArgs e) => Pane<Panes.RunPaneViewModel>("Run")?.Run();
 
-	void OnRefreshChecks(object? s, RoutedEventArgs e)
+	void OnRefreshChecks(object? s, EventArgs e)
 	{
 		App.Workspace?.Factory?.ShowPane("Checks");
 		App.Workspace?.RequestChecksRefresh();
@@ -391,31 +466,36 @@ public partial class MainWindow : Window
 		return factory.Pane<T>(id);
 	}
 
+	void OnMenuOpening(object? s, EventArgs e) => RefreshMenus();
+
 	/// <summary>
 	/// What the menu can offer that depends on the tab in front. The review's own state is
 	/// bound - it has events to change on - but which document is active, whether its blame
 	/// margin is showing and how deeply its file is meant to be read have none. Read when the
-	/// menu opens, which is the only moment it matters and the only one that cannot be stale.
+	/// menu opens, which is the only moment it matters and the only one that cannot be stale -
+	/// and by the screenshot watcher, which invokes an item straight out of the model without
+	/// opening anything, so nothing else would have filled the submenus it looks in.
 	/// </summary>
-	void OnMenuOpening(object? s, RoutedEventArgs e)
+	internal void RefreshMenus()
 	{
 		var view = View;
 		var file = App.Workspace?.CurrentFile;
-		MultiRowTabsItem.IsChecked = TabRowsPreference.MultiRow;
+		multiRowTabsItem.IsChecked = TabRowsPreference.MultiRow;
 #if DEBUG
-		PointerCrossHairItem.IsVisible = true;
-		PointerCrossHairItem.IsChecked = Editor.PointerCrossHairRenderer.IsEnabled;
+		pointerCrossHairItem.IsVisible = true;
+		pointerCrossHairItem.IsChecked = Editor.PointerCrossHairRenderer.IsEnabled;
 #endif
+		FillRecentMenu();
 		FillBuildSolutionMenu();
-		BackItem.IsEnabled = App.Workspace?.CanGoBack ?? false;
-		ForwardItem.IsEnabled = App.Workspace?.CanGoForward ?? false;
-		NextHunkItem.IsEnabled = Has(ReviewCommands.JumpToHunk);
-		PrevHunkItem.IsEnabled = Has(ReviewCommands.JumpToHunk);
-		NextUncoveredItem.IsEnabled = Has(ReviewCommands.JumpToUncovered);
-		SideBySideItem.IsChecked = DiffLayoutPreference.SideBySide;
-		BlameItem.IsEnabled = Has(ReviewCommands.ToggleBlame);
-		BlameItem.IsChecked = view?.BlameVisible ?? false;
-		DebugHereItem.IsEnabled = Has(ReviewCommands.DebugHere);
-		HistoryOfSelectionItem.IsEnabled = Has(ReviewCommands.HistoryOfSelection);
+		backItem.IsEnabled = App.Workspace?.CanGoBack ?? false;
+		forwardItem.IsEnabled = App.Workspace?.CanGoForward ?? false;
+		nextHunkItem.IsEnabled = Has(ReviewCommands.JumpToHunk);
+		prevHunkItem.IsEnabled = Has(ReviewCommands.JumpToHunk);
+		nextUncoveredItem.IsEnabled = Has(ReviewCommands.JumpToUncovered);
+		sideBySideItem.IsChecked = DiffLayoutPreference.SideBySide;
+		blameItem.IsEnabled = Has(ReviewCommands.ToggleBlame);
+		blameItem.IsChecked = view?.BlameVisible ?? false;
+		debugHereItem.IsEnabled = Has(ReviewCommands.DebugHere);
+		historyOfSelectionItem.IsEnabled = Has(ReviewCommands.HistoryOfSelection);
 	}
 }

--- a/src/Stampeded/ScreenshotWatcher.cs
+++ b/src/Stampeded/ScreenshotWatcher.cs
@@ -256,17 +256,17 @@ static class ScreenshotWatcher
 				foreach (var command in lines.Where(l => l.StartsWith("menu:", StringComparison.Ordinal)))
 				{
 					string header = command["menu:".Length..].Trim();
-					// The logical tree, not the visual one: a submenu's items are not realized
-					// until the menu is opened, and this has to work without opening it.
-					if (Avalonia.LogicalTree.LogicalExtensions.GetLogicalDescendants(window).OfType<MenuItem>()
-						.FirstOrDefault(m => m.Header as string == header) is { } item)
-					{
-						item.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
-					}
+					// The menu model, not the window's tree: on macOS the menu is not in the
+					// window at all, and the bar drawn inside one builds its items only once a
+					// submenu opens. The model is the one place all three platforms share - and
+					// the items that are filled when a menu opens have to be filled first, since
+					// nothing is being opened here.
+					if (window is MainWindow main)
+						main.RefreshMenus();
+					if (MainWindow.FindMenuItem(NativeMenu.GetMenu(window), i => i.Header == header) is { } item)
+						((INativeMenuItemExporterEventsImplBridge)item).RaiseClicked();
 					else
-					{
 						CliLog.Write("action", $"menu: no item headed '{header}'");
-					}
 				}
 				// click:<name or label> - presses a button, for commands that have no gesture to
 				// raise and no view model the watcher can reach. The name wins over the label,


### PR DESCRIPTION
The menu bar was an Avalonia `Menu` docked at the top of the window - correct on Windows and Linux, and on macOS a strip no other application has. It is now a `NativeMenu`: a `NativeMenuBar` stays in the window and hides itself when the platform takes the menu, so macOS gets it in the system bar and nothing changes elsewhere.

What the port had to work around, since a menu item is a model object rather than a control:

- no `x:Name` - the twelve items the code-behind reaches carry a key as their `CommandParameter` and are looked up once in the constructor
- no `ItemsSource` - the recent repositories are built when the menu opens, next to the solutions that already were
- no `SubmenuOpened` - the refresh hangs off `NeedsUpdate` for the exported menu and off the routed event the in-window bar raises
- pane entries carry their pane id where they used to carry a `Tag`
- `Exit` and the rule above it are removed on macOS, where Quit lives in the application menu; an empty `NativeMenu` on the `Application` is what stops Avalonia from synthesising an "About Avalonia" one
- `ToolTip.ShowOnDisabled` moves to a style, because a `NativeMenuItem` carries only the tooltip text

No gesture becomes a `NativeMenuItem.Gesture`, including the four that were `InputGesture`s: on macOS that registers a real AppKit key equivalent which fires before the focused text box sees the key, so Option+Left would navigate the review instead of moving the caret in a comment. Every gesture stays where the window has always handled it, written into the header for the reader. Cmd-based shortcuts on macOS are a separate change.

The screenshot watcher's `menu:` command searched the window's logical tree for a `MenuItem`; there is none to find, so it now finds the item in the model.

## Verified on macOS

- the window opens with no menu strip - the menu went to the system bar
- `IsEnabled` and `ToolTip` bindings resolve against the window's DataContext (checked with a temporary probe: `Close Review=False`, `Commit by Commit` tip "No review is open.")
- `Click` handlers declared in XAML on a `NativeMenuItem` fire (Open from URL opens its dialog; Prune Worktree Cache pruned two)
- the pane entries bring their pane forward
- Recent Repositories and Solution to Build fill when the menu opens
- with `MacOSPlatformOptions.DisableNativeMenus` set temporarily, the in-window bar renders Review / Navigate / Tools / View / Help and its open-refresh fires

Not checkable from this session: the look of the macOS system menu bar itself, since this environment has neither screen-recording nor accessibility permission. Worth an eyeball.

`dotnet test` is green apart from three pre-existing `/var` vs `/private/var` path failures in `Stampeded.Core` worktree tests, which this branch does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWwN5yyjWRyP4Tpxqyt8Ct