### PR TITLE
Build the venv a Python test needs instead of imitating one

### DIFF
--- a/tests/Stampeded.Core.Tests/PythonInterpreterTests.cs
+++ b/tests/Stampeded.Core.Tests/PythonInterpreterTests.cs
@@ -18,13 +18,17 @@ public class PythonInterpreterTests
 		string repo = NewTempDir();
 		try
 		{
-			string interpreter = FakeEnvironment(Path.Combine(repo, ".venv"));
+			if (PythonVenv.Create(Path.Combine(repo, ".venv")) is not { } interpreter)
+			{
+				Assert.Ignore("no Python interpreter available");
+				return;
+			}
 
 			Assert.That(PythonEnvironment.InterpreterFor(repo), Is.EqualTo(interpreter));
 		}
 		finally
 		{
-			Directory.Delete(repo, recursive: true);
+			TempDirectory.Delete(repo);
 		}
 	}
 
@@ -42,7 +46,7 @@ public class PythonInterpreterTests
 		}
 		finally
 		{
-			Directory.Delete(repo, recursive: true);
+			TempDirectory.Delete(repo);
 		}
 	}
 
@@ -60,8 +64,12 @@ public class PythonInterpreterTests
 		try
 		{
 			// The clone: an environment with one package in it, and nothing else.
-			string interpreter = FakeEnvironment(Path.Combine(repo, ".venv"));
-			string package = Path.Combine(repo, ".venv", "lib", "python" + PythonVersion(), "site-packages", "mylib");
+			if (PythonVenv.Create(Path.Combine(repo, ".venv")) is not { } interpreter)
+			{
+				Assert.Ignore("no Python interpreter available");
+				return;
+			}
+			string package = Path.Combine(PythonVenv.SitePackages(interpreter), "mylib");
 			Directory.CreateDirectory(package);
 			File.WriteAllText(Path.Combine(package, "__init__.py"), """
 				def hello(name):
@@ -96,42 +104,9 @@ public class PythonInterpreterTests
 		finally
 		{
 			connection?.Dispose();
-			Directory.Delete(repo, recursive: true);
-			Directory.Delete(worktree, recursive: true);
+			TempDirectory.Delete(repo);
+			TempDirectory.Delete(worktree);
 		}
-	}
-
-	/// <summary>
-	/// A virtual environment as Python itself recognises one: a pyvenv.cfg beside a bin
-	/// directory whose python is the system's. Building a real one would take a minute and
-	/// prove the same thing, which is that an interpreter reports its own site-packages.
-	/// </summary>
-	static string FakeEnvironment(string root)
-	{
-		string bin = OperatingSystem.IsWindows() ? "Scripts" : "bin";
-		Directory.CreateDirectory(Path.Combine(root, bin));
-		File.WriteAllText(Path.Combine(root, "pyvenv.cfg"),
-			$"home = /usr/bin\nversion = {PythonVersion()}\n");
-		string interpreter = Path.Combine(root, bin, OperatingSystem.IsWindows() ? "python.exe" : "python");
-		File.CreateSymbolicLink(interpreter, SystemPython());
-		return interpreter;
-	}
-
-	static string SystemPython()
-		=> new[] { "/usr/bin/python3", "/usr/local/bin/python3" }.FirstOrDefault(File.Exists)
-			?? throw new InvalidOperationException("no system python3");
-
-	/// <summary>The system interpreter's major.minor, which is what names its site-packages
-	/// directory.</summary>
-	static string PythonVersion()
-	{
-		var process = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(SystemPython()) {
-			ArgumentList = { "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" },
-			RedirectStandardOutput = true,
-		})!;
-		string version = process.StandardOutput.ReadToEnd().Trim();
-		process.WaitForExit();
-		return version;
 	}
 
 	static string NewTempDir()

--- a/tests/Stampeded.Core.Tests/PythonLspTests.cs
+++ b/tests/Stampeded.Core.Tests/PythonLspTests.cs
@@ -89,7 +89,7 @@ public class PythonLspTests
 		finally
 		{
 			connection?.Dispose();
-			Directory.Delete(dir, recursive: true);
+			TempDirectory.Delete(dir);
 		}
 	}
 

--- a/tests/Stampeded.Core.Tests/PythonProjectConfigTests.cs
+++ b/tests/Stampeded.Core.Tests/PythonProjectConfigTests.cs
@@ -25,7 +25,11 @@ public class PythonProjectConfigTests
 		LspConnection? connection = null;
 		try
 		{
-			string interpreter = FakeVenv(clone);
+			if (CloneWithPackage(clone) is not { } interpreter)
+			{
+				Assert.Ignore("no Python interpreter available");
+				return;
+			}
 			// The worktree is a checkout: it has the committed config, and no environment.
 			File.WriteAllText(Path.Combine(worktree, "pyproject.toml"), """
 				[tool.pyright]
@@ -55,41 +59,24 @@ public class PythonProjectConfigTests
 		finally
 		{
 			connection?.Dispose();
-			Directory.Delete(clone, recursive: true);
-			Directory.Delete(worktree, recursive: true);
+			TempDirectory.Delete(clone);
+			TempDirectory.Delete(worktree);
 		}
 	}
 
-	static string FakeVenv(string root)
+	/// <summary>The reader's own clone: an environment with the package the project depends
+	/// on, which is the thing the worktree does not have.</summary>
+	static string? CloneWithPackage(string root)
 	{
-		string version = PythonVersionOf(SystemPython());
-		string bin = OperatingSystem.IsWindows() ? "Scripts" : "bin";
-		Directory.CreateDirectory(Path.Combine(root, ".venv", bin));
-		string packages = Path.Combine(root, ".venv", "lib", "python" + version, "site-packages", "mylib");
+		if (PythonVenv.Create(Path.Combine(root, ".venv")) is not { } interpreter)
+			return null;
+		string packages = Path.Combine(PythonVenv.SitePackages(interpreter), "mylib");
 		Directory.CreateDirectory(packages);
 		File.WriteAllText(Path.Combine(packages, "__init__.py"), """
 			def hello(name):
 				return "hi " + name
 			""");
-		File.WriteAllText(Path.Combine(root, ".venv", "pyvenv.cfg"), $"home = /usr/bin\nversion = {version}\n");
-		string interpreter = Path.Combine(root, ".venv", bin, OperatingSystem.IsWindows() ? "python.exe" : "python");
-		File.CreateSymbolicLink(interpreter, SystemPython());
 		return interpreter;
-	}
-
-	static string SystemPython()
-		=> new[] { "/usr/bin/python3", "/usr/local/bin/python3" }.FirstOrDefault(File.Exists)
-			?? throw new InvalidOperationException("no system python3");
-
-	static string PythonVersionOf(string interpreter)
-	{
-		var process = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(interpreter) {
-			ArgumentList = { "-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" },
-			RedirectStandardOutput = true,
-		})!;
-		string version = process.StandardOutput.ReadToEnd().Trim();
-		process.WaitForExit();
-		return version;
 	}
 
 	static string NewTempDir()

--- a/tests/Stampeded.Core.Tests/PythonVenv.cs
+++ b/tests/Stampeded.Core.Tests/PythonVenv.cs
@@ -1,0 +1,51 @@
+using Stampeded.Core.Lsp;
+
+namespace Stampeded.Core.Tests;
+
+/// <summary>
+/// A real virtual environment for a test to point a language server at.
+///
+/// Real because a hand-built one is not an interpreter: a pyvenv.cfg beside a symlink is how a
+/// venv looks, but whether Python recognises it depends on what the symlink resolves to. On
+/// macOS /usr/bin/python3 is the Command Line Tools stub, which re-execs the real binary, so
+/// sys.executable is the framework's path, the planted pyvenv.cfg is never seen and the
+/// environment's site-packages is never on sys.path. `python -m venv` gets this right on every
+/// platform, takes a fraction of a second without pip, and lays the directories out the way the
+/// platform actually does.
+/// </summary>
+static class PythonVenv
+{
+	/// <summary>The interpreter inside a new environment at <paramref name="root"/>, or null on
+	/// a machine with no Python - where a test that needs one has nothing to say.</summary>
+	public static string? Create(string root)
+	{
+		if ((LanguageServers.OnPath("python3") ?? LanguageServers.OnPath("python")) is not { } python)
+			return null;
+		// No pip: it is a download and a second or two, and nothing here installs a package.
+		if (Run(python, "-m", "venv", "--without-pip", root) is null)
+			return null;
+		string interpreter = Path.Combine(root, OperatingSystem.IsWindows() ? "Scripts" : "bin",
+			OperatingSystem.IsWindows() ? "python.exe" : "python");
+		return File.Exists(interpreter) ? interpreter : null;
+	}
+
+	/// <summary>Where a package has to be written for that interpreter to import it, asked of
+	/// the interpreter rather than guessed - the layout differs by platform and by version.</summary>
+	public static string SitePackages(string interpreter)
+		=> Run(interpreter, "-c", "import sysconfig; print(sysconfig.get_paths()['purelib'])")
+			?? throw new InvalidOperationException($"{interpreter} does not report its site-packages");
+
+	/// <summary>The command's standard output, or null if it did not run or failed.</summary>
+	static string? Run(string executable, params string[] arguments)
+	{
+		var start = new System.Diagnostics.ProcessStartInfo(executable) { RedirectStandardOutput = true };
+		foreach (string argument in arguments)
+			start.ArgumentList.Add(argument);
+		using var process = System.Diagnostics.Process.Start(start);
+		if (process is null)
+			return null;
+		string output = process.StandardOutput.ReadToEnd().Trim();
+		process.WaitForExit(TimeSpan.FromMinutes(1));
+		return process.HasExited && process.ExitCode == 0 ? output : null;
+	}
+}


### PR DESCRIPTION
The first CI run across three operating systems ([run 33433853550](https://github.com/icsharpcode/Stampeded/actions/runs/33433853550)) is red on Windows (4 failures) and macOS (2), green on Linux. Nothing in the product regressed - the build succeeds everywhere - the tests were written against a POSIX machine.

| Test | Windows | macOS |
|---|---|---|
| `TheProjectsOwnEnvironmentIsPreferredToWhateverIsOnPath` | `no system python3` | passes |
| `AnImportResolvesIntoAnEnvironmentThatIsNotInTheWorktree` | `no system python3` | definition null |
| `AProjectConfigNamingItsOwnVenvDoesNotBlindTheReview` | `no system python3` | definition null |
| `PyrightAnswersDefinitionsAndReferencesAcrossFiles` | `IOException` deleting the temp dir | passes |

**The fake environment is not an interpreter on macOS.** A `pyvenv.cfg` beside a symlink at `/usr/bin/python3` is how a venv looks, but `/usr/bin/python3` there is the Command Line Tools stub: it re-execs the real binary, so `sys.executable` becomes the framework path, the planted `pyvenv.cfg` is never seen, and the fake `site-packages` never reaches `sys.path`. Pyright logs `Unable to get Python version from interpreter` and resolves the import to nothing. Reproduced locally and fixed there. The layout was POSIX-only anyway - a venv on Windows keeps packages in `Lib\site-packages`.

**`SystemPython()` hardcoded `/usr/bin/python3`,** so it threw on every Windows machine whatever Python was installed - three of the four Windows failures.

**The fourth was cleanup**, not an assertion: `Directory.Delete` while pyright's node process still holds the workspace root. `TempDirectory.Delete` exists for exactly that and is what every other test uses.

So: one `PythonVenv` helper that builds a real environment with `python -m venv --without-pip` (a tenth of a second, no network) and asks the interpreter where its packages go. The Python to build it with comes from `LanguageServers.OnPath`, which already knows a bare name on Windows means PATHEXT; with no Python at all the test is ignored instead of throwing. ~60 lines of duplicated fakes go.

Tests only - no product code, no workflow change. All three runners already have a Python, so these run rather than skip everywhere.

Verified locally on macOS: red first (same failure as CI), then 261/261 green in Release. Windows is what this PR's own CI is for.