### PR TITLE
Repaint the Simple theme instead of wearing its defaults

### DIFF
--- a/src/Stampeded/App.axaml
+++ b/src/Stampeded/App.axaml
@@ -22,12 +22,69 @@
           <SolidColorBrush x:Key="Stampeded.EditorSelectionBrush" Color="#007ACC" Opacity="0.3" />
           <SolidColorBrush x:Key="Stampeded.TreeFocusFill" Color="#33007ACC" />
           <SolidColorBrush x:Key="Stampeded.TreeFocusBorder" Color="#005A9E" />
+          <!-- The ground the window is built on, a shade off the white that content is
+               painted in, so a list or an editor reads as a surface laid on the frame rather
+               than as more of the same sheet. -->
+          <SolidColorBrush x:Key="Stampeded.ChromeBackground" Color="#F4F5F7" />
+          <!-- The Simple theme's own palette, restated. Its defaults draw a near-black
+               hairline around every list and text box and shade the buttons like a Win32
+               dialog; a review is read for an hour at a time, and the frame should be quiet
+               enough to disappear. Only the brushes are overridden, not the colours behind
+               them: the theme builds each brush from its colour with a StaticResource, which
+               is resolved once at parse time and never looks back. -->
+          <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="#FFFFFF" />
+          <SolidColorBrush x:Key="ThemeBorderLowBrush" Color="#E4E7EA" />
+          <SolidColorBrush x:Key="ThemeBorderMidBrush" Color="#D8DCE1" />
+          <SolidColorBrush x:Key="ThemeBorderHighBrush" Color="#B9C0C8" />
+          <SolidColorBrush x:Key="ThemeControlLowBrush" Color="#F0F2F5" />
+          <SolidColorBrush x:Key="ThemeControlMidBrush" Color="#F6F7F9" />
+          <SolidColorBrush x:Key="ThemeControlMidHighBrush" Color="#F0F2F5" />
+          <SolidColorBrush x:Key="ThemeControlHighBrush" Color="#ECEFF3" />
+          <SolidColorBrush x:Key="ThemeControlVeryHighBrush" Color="#FFFFFF" />
+          <SolidColorBrush x:Key="ThemeControlHighlightLowBrush" Color="#F6F7F9" />
+          <SolidColorBrush x:Key="ThemeControlHighlightMidBrush" Color="#ECEFF3" />
+          <SolidColorBrush x:Key="ThemeControlHighlightHighBrush" Color="#E1E5EA" />
+          <SolidColorBrush x:Key="ThemeForegroundBrush" Color="#1F2328" />
+          <SolidColorBrush x:Key="ThemeForegroundLowBrush" Color="#656D76" />
+          <SolidColorBrush x:Key="ThemeAccentBrush" Color="#3794FF" />
+          <SolidColorBrush x:Key="HighlightBrush" Color="#3794FF" />
+          <SolidColorBrush x:Key="ThemeAccentBrush2" Color="#993794FF" />
+          <SolidColorBrush x:Key="ThemeAccentBrush3" Color="#663794FF" />
+          <SolidColorBrush x:Key="ThemeAccentBrush4" Color="#333794FF" />
+          <Color x:Key="ThemeBackgroundColor">#FFFFFF</Color>
+          <Color x:Key="ThemeForegroundColor">#1F2328</Color>
+          <Color x:Key="ThemeBorderLowColor">#E4E7EA</Color>
+          <Color x:Key="ThemeAccentColor">#3794FF</Color>
         </ResourceDictionary>
         <ResourceDictionary x:Key="Dark">
           <SolidColorBrush x:Key="Stampeded.EditorBackground" Color="#1E1E1E" />
           <SolidColorBrush x:Key="Stampeded.EditorSelectionBrush" Color="#3794FF" Opacity="0.35" />
           <SolidColorBrush x:Key="Stampeded.TreeFocusFill" Color="#40007ACC" />
           <SolidColorBrush x:Key="Stampeded.TreeFocusBorder" Color="#4A90D9" />
+          <SolidColorBrush x:Key="Stampeded.ChromeBackground" Color="#181A1C" />
+          <SolidColorBrush x:Key="ThemeBackgroundBrush" Color="#1E1E1E" />
+          <SolidColorBrush x:Key="ThemeBorderLowBrush" Color="#2A2E33" />
+          <SolidColorBrush x:Key="ThemeBorderMidBrush" Color="#3A4046" />
+          <SolidColorBrush x:Key="ThemeBorderHighBrush" Color="#555D66" />
+          <SolidColorBrush x:Key="ThemeControlLowBrush" Color="#23272B" />
+          <SolidColorBrush x:Key="ThemeControlMidBrush" Color="#33383E" />
+          <SolidColorBrush x:Key="ThemeControlMidHighBrush" Color="#26292E" />
+          <SolidColorBrush x:Key="ThemeControlHighBrush" Color="#2A2E33" />
+          <SolidColorBrush x:Key="ThemeControlVeryHighBrush" Color="#33383E" />
+          <SolidColorBrush x:Key="ThemeControlHighlightLowBrush" Color="#33383E" />
+          <SolidColorBrush x:Key="ThemeControlHighlightMidBrush" Color="#3D434A" />
+          <SolidColorBrush x:Key="ThemeControlHighlightHighBrush" Color="#474E56" />
+          <SolidColorBrush x:Key="ThemeForegroundBrush" Color="#E6EDF3" />
+          <SolidColorBrush x:Key="ThemeForegroundLowBrush" Color="#8B949E" />
+          <SolidColorBrush x:Key="ThemeAccentBrush" Color="#3794FF" />
+          <SolidColorBrush x:Key="HighlightBrush" Color="#3794FF" />
+          <SolidColorBrush x:Key="ThemeAccentBrush2" Color="#993794FF" />
+          <SolidColorBrush x:Key="ThemeAccentBrush3" Color="#663794FF" />
+          <SolidColorBrush x:Key="ThemeAccentBrush4" Color="#333794FF" />
+          <Color x:Key="ThemeBackgroundColor">#1E1E1E</Color>
+          <Color x:Key="ThemeForegroundColor">#E6EDF3</Color>
+          <Color x:Key="ThemeBorderLowColor">#2F343A</Color>
+          <Color x:Key="ThemeAccentColor">#3794FF</Color>
         </ResourceDictionary>
       </ResourceDictionary.ThemeDictionaries>
       <ResourceDictionary.MergedDictionaries>
@@ -47,6 +104,41 @@
          panes here are resizable and their buttons are labelled with sentences. -->
     <Style Selector="Button TextBlock">
       <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+    </Style>
+    <!-- A corner radius the whole window over. The Simple theme draws every control as a
+         hard-edged rectangle, which reads as unfinished next to the rounded chrome every
+         other tool on the platform has. Set before Button.tool below, since equal-specificity
+         styles apply in source order and a toolbar button keeps its own tighter radius. -->
+    <Style Selector="Button">
+      <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style Selector="ToggleButton">
+      <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style Selector="TextBox">
+      <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style Selector="ComboBox">
+      <Setter Property="CornerRadius" Value="4" />
+    </Style>
+    <Style Selector="ListBox">
+      <Setter Property="CornerRadius" Value="5" />
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="ListBox /template/ Border#border">
+      <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
+    </Style>
+    <Style Selector="ListBoxItem">
+      <Setter Property="CornerRadius" Value="3" />
+    </Style>
+    <!-- A pane's and a document's content are the surfaces a review is read on, so they keep
+         the content colour while the frame around them carries the chrome tone. Without this
+         they would inherit whatever the window is painted in, which is now not white. -->
+    <Style Selector="dockControls|ToolContentControl">
+      <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
+    </Style>
+    <Style Selector="dockControls|DocumentContentControl">
+      <Setter Property="Background" Value="{DynamicResource ThemeBackgroundBrush}" />
     </Style>
     <!-- A row of commands over a list is a toolbar: pressed with the mouse, read at a glance,
          and narrow enough that a pane keeps room for what it is about. The name each icon

--- a/src/Stampeded/Documents/StartDocumentView.axaml
+++ b/src/Stampeded/Documents/StartDocumentView.axaml
@@ -79,7 +79,10 @@
       <Setter Property="Height" Value="14" />
     </Style>
   </UserControl.Styles>
-  <Grid ColumnDefinitions="1*,8,2*,8,2*" Margin="8">
+  <!-- The chrome tone behind the three columns, so their lists read as three panels and not
+       as one sheet with lines drawn on it: the gutters are what separates them. -->
+  <Grid ColumnDefinitions="1*,8,2*,8,2*" Margin="8"
+        Background="{DynamicResource Stampeded.ChromeBackground}">
     <DockPanel Grid.Column="0">
       <Grid DockPanel.Dock="Top" Classes="header" ColumnDefinitions="*,Auto">
         <Panel Classes="headtitle">

--- a/src/Stampeded/MainWindow.axaml
+++ b/src/Stampeded/MainWindow.axaml
@@ -210,11 +210,12 @@
     <LayoutTransformControl.LayoutTransform>
       <ScaleTransform ScaleX="{Binding Zoom}" ScaleY="{Binding Zoom}" />
     </LayoutTransformControl.LayoutTransform>
-  <DockPanel>
+  <DockPanel Background="{DynamicResource Stampeded.ChromeBackground}">
     <!-- Empty and zero-height on macOS, where the platform took the menu; the bar the menu is
          drawn in on Windows and Linux. -->
     <NativeMenuBar DockPanel.Dock="Top" />
-    <Border DockPanel.Dock="Bottom" Padding="8,3" IsVisible="{Binding Busy.IsBusy}">
+    <Border DockPanel.Dock="Bottom" Padding="8,3" IsVisible="{Binding Busy.IsBusy}"
+            BorderBrush="{DynamicResource ThemeBorderLowBrush}" BorderThickness="0,1,0,0">
       <StackPanel Orientation="Horizontal" Spacing="8">
         <TextBlock Text="{Binding Busy.SpinnerFrame}" FontFamily="monospace" />
         <TextBlock Text="{Binding Busy.Text}" Opacity="0.8" />


### PR DESCRIPTION
The window read as an unstyled toolkit demo. Not because anyone chose that look, but because
nothing overrode the Simple theme's defaults: a near-black hairline around every list and text
box, a hard rectangle for every control, one white for chrome and content alike, and buttons
shaded like a Win32 dialog.

This repaints the theme. No layout moved, no control was added, no view was restructured, and
the scope accent (`ScopePalette`, blue / purple / orange) is untouched because it carries
meaning. Three files, +99 lines, all of it declarative.

## Before

<img width="1512" height="921" alt="before" src="https://github.com/user-attachments/assets/aa92ccfa-07fd-4de3-8546-9fcfaae6383a" />


## After

<img width="1512" height="921" alt="after-final" src="https://github.com/user-attachments/assets/d878d5ad-124e-4ec1-a00d-94e9de1144bb" />

## Dark

<img width="1512" height="921" alt="dark-probe" src="https://github.com/user-attachments/assets/1d33a05e-7341-4e40-ab58-d8e82034671d" />

Dark is unreachable in the app today - nothing calls `ThemeManager.UpdateTheme`, so the Theme
menu was never wired up - but leaving its dictionary stock would have made it wrong the moment
something does. Captured by forcing `RequestedThemeVariant="Dark"` for one build, then reverting.

## What actually changed

Measured off the two captures, not eyeballed:

| | before | after |
|---|---|---|
| list / text-box border | `#888888` | `#D8DCE1` |
| button face | Win32 gradient | flat `#F6F7F9` |
| corner radius | `0` everywhere | 4px controls, 5px lists, 3px rows |
| chrome ground | `#FFFFFF` | `#F4F5F7` |
| primary text | `#000000` | `#1F2328` |
| secondary text | `#000000` at opacity | `#656D76` |
| list selection | stock Avalonia `#119EDA` | `#3794FF` at 33 / 66 / 99% |

## How it is done

`src/Stampeded/App.axaml` carries almost all of it, because the theme resolves every colour
through a named resource key and `Application.Resources` is consulted before
`Application.Styles`. Restating the keys repaints the whole app without touching a template.

Two details that are not obvious and are the reason both halves of the palette are present:

- **Brushes, not colours, for the Simple theme.** It builds each brush from its colour with a
  `StaticResource`, resolved once at parse time. Overriding `ThemeBorderMidColor` alone does
  nothing to `ThemeBorderMidBrush`.
- **Colours, not brushes, for Dock.** It ignores the `Theme*Brush` keys entirely and builds its
  own `Dock*` brushes from `ThemeBackgroundColor` / `ThemeForegroundColor` /
  `ThemeBorderLowColor` / `ThemeAccentColor` with a `DynamicResource` - the opposite
  arrangement. Without the colour keys the dock chrome would have stayed stock while everything
  around it moved.

Also worth knowing: `ThemeControlHighBrush` is the *pressed* face, not a lighter shade -
Control**High** is high emphasis, not high luminance. Setting it lighter than
`ThemeControlMidBrush` would have made a pressed button brighten. And `ThemeAccentBrush2/3/4`,
not `HighlightBrush`, are what paint list, tree and tab selection.

The other two files:

- `MainWindow.axaml` - the root `DockPanel` takes the chrome tone (this is what shows behind
  the tab strips, the splitters and the menu bar), and the status bar gets a top hairline.
- `StartDocumentView.axaml` - one `Background` on the existing three-column grid, which is what
  turns its 8px gutters into ground and makes the three lists read as three panels.

To keep every existing pane and document looking exactly as it does today, the dock's
`ToolContentControl` and `DocumentContentControl` are pinned to the content colour, so only the
frame around them carries the tone. Verified: every content surface sampled is still `#FFFFFF`.

## Two things chased and dropped

- **A rounded document tab.** Dock fills the tab with a `Panel`, which has no `CornerRadius` to
  bind, so the setter had nowhere to land. Three selectors were tried against the template and
  all reverted rather than left as dead setters. It needs a template replacement.
- **A leaking rounded corner.** `ListBox` applies its `Background` to the `ScrollViewer` *inside*
  its border, so the square fill poked out of the new 5px corners. Fixed by painting
  `/template/ Border#border` and leaving the inside clear - visible in the pixel at (315, 64),
  which went from white to the chrome tone.

## Verification

- `dotnet build Stampeded.slnx` - clean, 0 warnings. Compiled bindings are on and
  `TreatWarningsAsErrors` is set, so a bad resource key or selector would have failed the build.
- Light and dark both captured and checked; no content surface went grey by accident.
- `dotnet test` could not run here: the test host aborts with `Microsoft.NETCore.App
  framework_version=10.0.0 arch=arm64` missing. This reproduces on a clean `main`, so it is the
  machine and not this change. The tests cover `Stampeded.Core`, which has no Avalonia
  reference and is not touched.
- **Not verified:** a diff document was not opened. No editor resource was changed -
  `HighlightColor` and the `Stampeded.Editor*` keys are untouched, and AvaloniaEdit's brushes
  are pinned to the `Default` variant dictionary, so the `Light` overrides here are invisible to
  it - but that is reasoning, not a screenshot.

## Out of scope

Real work the exploration turned up, each better as its own change:

- **The colour literals.** `#2EA043` / `#F85149` / `#D29922` / `#40808080` and friends are
  repeated verbatim about thirty times across ten `.axaml` files and about thirty more times in
  C# (`OverviewDocumentViewModel.cs:142`, `StartDocumentViewModel.cs:90`,
  `Diff/DiffLineBackgroundRenderer.cs:20`, `Panes/ChangeMapPaneViewModel.cs:60`, and others).
  They are a de-facto GitHub Primer palette that nothing names.
- **Three copies of card chrome** with three different corner radii for one visual idea:
  `ReviewDocumentView.axaml:25` (3), `CommentsPaneView.axaml:48` (3),
  `OverviewDocumentView.axaml:98` (3), and the popup border repeated at
  `DiffDocumentView.axaml:39` (4), `SideBySideDocumentView.axaml:15` (4), `MainWindow.axaml:227` (6).
- **The dock chrome.** `ToolChromeControl`, `ToolTabStripItem` and `ProportionalStackPanelSplitter`
  are still raw theme - the pane title bars and the bottom tab strip are the last unstyled
  surfaces. The hooks exist (`PART_Grip` for a tool title bar, `DockSurfacePanelBrush`,
  `DockSplitterIdleBrush`), but `ToolTabStripItem` does not template-bind `CornerRadius` at all,
  so part of it means replacing templates. Same obstacle as the document tab above.
- **A dark-mode bug in the vendored tree view.** `Controls/TreeView/SharpTreeView.axaml:18-26` -
  the expander's `#FFB0B0B0` border, white-to-`#FFC0B7A6` gradient and black arrow are
  hard-coded light-only, so it is wrong in dark. A bug rather than polish, and the file is
  vendored from ILSpy, so per `src/Stampeded.Core/TreeView/README.md` it wants fixing upstream too.
- **A status bar that vanishes.** `MainWindow.axaml:217` is `IsVisible`-bound to `Busy.IsBusy`,
  so the window's content shifts every time work starts and stops. Making it permanent is a
  behaviour change, not a style one.
- **The Theme menu.** `ThemeManager.UpdateTheme` has no caller, so the dark palette this PR
  fills in cannot be reached from the UI.
