### PR TITLE
Run the test suite through Microsoft Testing Platform

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,13 @@ jobs:
           path: test-results/*.trx
           if-no-files-found: error
 
+      - name: Create Test Report
+        uses: test-summary/action@v2
+        if: always()
+        with:
+          paths: test-results/*.trx
+          folded: true
+
       # Framework-dependent on purpose: the app needs an installed .NET SDK at runtime
       # anyway (Roslyn's MSBuild workspace, dotnet build/test), so bundling a runtime
       # would only grow the artifact. RID-specific so an apphost exists to launch.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,14 @@ jobs:
           dotnet-version: 10.0.x
 
       - run: dotnet build Stampeded.slnx -c Release
-      - run: dotnet test Stampeded.slnx -c Release --no-build
+      - run: dotnet test --solution Stampeded.slnx -c Release --no-build --report-trx --results-directory test-results
+
+      - uses: actions/upload-artifact@v7
+        if: success() || failure()
+        with:
+          name: test-results-${{ matrix.rid }}
+          path: test-results/*.trx
+          if-no-files-found: error
 
       # Framework-dependent on purpose: the app needs an installed .NET SDK at runtime
       # anyway (Roslyn's MSBuild workspace, dotnet build/test), so bundling a runtime

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,7 +161,12 @@ than with a tree at the wrong lines. A parser in this process answers before it 
 Prefix `dotnet` with `OPENSSL_ENABLE_SHA1_SIGNATURES=1` (the local OpenSSL setup needs it):
 
     OPENSSL_ENABLE_SHA1_SIGNATURES=1 dotnet build Stampeded.slnx
-    OPENSSL_ENABLE_SHA1_SIGNATURES=1 dotnet test Stampeded.slnx
+    OPENSSL_ENABLE_SHA1_SIGNATURES=1 dotnet test --solution Stampeded.slnx --report-trx --results-directory test-results
+
+`dotnet test` runs through Microsoft.Testing.Platform (`global.json` pins the runner), so the
+solution is named with `--solution` - the bare positional form is VSTest syntax and errors.
+`--report-trx` leaves a TRX per test assembly under `test-results/`, which is how a failure
+survives the run.
 
 Tests that exercise git create real repositories in temp directories and shell out to `git` -
 that is deliberate: the interesting behaviour is git's, and a mock would only assert what we

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,6 +27,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.9.0" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.3.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/tests/Stampeded.Core.Tests/Stampeded.Core.Tests.csproj
+++ b/tests/Stampeded.Core.Tests/Stampeded.Core.Tests.csproj
@@ -1,11 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+    <OutputType>Exe</OutputType>
+    <EnableNUnitRunner>true</EnableNUnitRunner>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Stampeded.Core\Stampeded.Core.csproj" />


### PR DESCRIPTION
Migrates the tests from the VSTest stack to Microsoft Testing Platform (MTP), following ILSpy's settled recipe.

- `global.json` (new) names `Microsoft.Testing.Platform` as the `dotnet test` runner — the .NET 10 SDK's native MTP support. No `sdk` pin; the repo has never had one.
- `Stampeded.Core.Tests.csproj`: `OutputType=Exe` + `EnableNUnitRunner=true`; `Microsoft.NET.Test.Sdk` removed (NUnit3TestAdapter 6.x is the runner itself), `Microsoft.Testing.Extensions.TrxReport` added.
- CI calls `dotnet test --solution Stampeded.slnx ... --report-trx --results-directory test-results` and uploads the TRX per matrix leg even when tests fail, so a failure survives the run.
- `CLAUDE.md` documents the new invocation — the bare positional `dotnet test <sln>` form is VSTest syntax and errors under MTP.

Deliberately skipped, as ILSpy's history showed them obsolete or unneeded: `dotnet.config` (superseded by the `global.json` test section), `TestingPlatformDotnetTestSupport`, and an explicit `VSTestBridge` reference (build is clean without it). `coverlet.MTP` is left out because nothing collects coverage today.

Verified locally on Windows: 262 tests, 257 passed / 4 skipped / 1 failed — the failure being the known symlink-privilege-only `DoesNotFollowASymlinkOutOfTheWorktree`, which passes on CI runners. TRX lands in `test-results/`, and `--filter FullyQualifiedName~...` still works (NUnit keeps the VSTest filter format under MTP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
