### PR TITLE
Await the language server's own async calls instead of blocking on them

### DIFF
--- a/src/Stampeded.RoslynLsp/RoslynLspServer.cs
+++ b/src/Stampeded.RoslynLsp/RoslynLspServer.cs
@@ -107,7 +107,7 @@ sealed class RoslynLspServer : IDisposable
 			case "textDocument/didChange":
 				// The client sends what the review is showing, which may be a revision that
 				// is not on disk. An overlay is how the workspace is told.
-				Overlay(parameters);
+				await OverlayAsync(parameters, ct);
 				break;
 			case "initialized":
 			case "$/cancelRequest":
@@ -206,8 +206,14 @@ sealed class RoslynLspServer : IDisposable
 		});
 	}
 
+	// An event handler cannot await, and the client only needs the notification to arrive
+	// eventually: the write lock queues waiters in order, so states are still sent in the
+	// order they were reached.
 	void ReportState()
-		=> Notify("stampeded/state", new { state = head.State.ToString(), detail = head.StateDetail });
+		=> NotifyAsync("stampeded/state", new { state = head.State.ToString(), detail = head.StateDetail })
+			.ContinueWith(
+				t => CliLog.Write("roslyn-lsp", $"state notification failed: {t.Exception?.GetBaseException().Message}"),
+				TaskContinuationOptions.OnlyOnFaulted);
 
 	/// <summary>Derives the base-side workspace from the head one, given the texts of the
 	/// revision being compared against.</summary>
@@ -242,7 +248,7 @@ sealed class RoslynLspServer : IDisposable
 		return texts;
 	}
 
-	void Overlay(JsonElement parameters)
+	async Task OverlayAsync(JsonElement parameters, CancellationToken ct)
 	{
 		if (!parameters.TryGetProperty("textDocument", out var document)
 			|| !document.TryGetProperty("uri", out var uri))
@@ -261,7 +267,7 @@ sealed class RoslynLspServer : IDisposable
 		// Only when it differs from what the workspace has: the client opens a document to
 		// be able to ask about it at all, and re-stating the file on disk would throw away
 		// the compilation that already knows it.
-		if (target.Service.GetDocumentTextAsync(target.RelPath, CancellationToken.None).Result is { } current
+		if (await target.Service.GetDocumentTextAsync(target.RelPath, ct) is { } current
 			&& string.Equals(current.ReplaceLineEndings("\n"), text.ReplaceLineEndings("\n"), StringComparison.Ordinal))
 		{
 			return;
@@ -619,11 +625,11 @@ sealed class RoslynLspServer : IDisposable
 		await SendAsync(payload);
 	}
 
-	void Notify(string method, object parameters)
+	Task NotifyAsync(string method, object parameters)
 	{
 		var payload = JsonSerializer.SerializeToUtf8Bytes(
 			new { jsonrpc = "2.0", method, @params = parameters }, Json);
-		SendAsync(payload).GetAwaiter().GetResult();
+		return SendAsync(payload);
 	}
 
 	async Task SendAsync(byte[] payload)

--- a/tests/Stampeded.Core.Tests/GeneratedSourcesTests.cs
+++ b/tests/Stampeded.Core.Tests/GeneratedSourcesTests.cs
@@ -54,13 +54,13 @@ public class GeneratedSourcesTests
 	}
 
 	[Test]
-	public void PairsTheTwoSidesEvenWhenTheyWereBuiltDifferently()
+	public async Task PairsTheTwoSidesEvenWhenTheyWereBuiltDifferently()
 	{
 		string baseTree = NewDirectory(), headTree = NewDirectory();
 		Write(baseTree, "src/Lib/obj/Debug/net10.0/generated/G/E/Thing.g.cs", "one\ntwo\n");
 		Write(headTree, "src/Lib/obj/Release/net11.0/generated/G/E/Thing.g.cs", "one\ntwo changed\n");
 
-		var files = GeneratedSources.DiffAsync(baseTree, headTree).GetAwaiter().GetResult();
+		var files = await GeneratedSources.DiffAsync(baseTree, headTree);
 
 		Assert.That(files, Has.Count.EqualTo(1));
 		Assert.That(files[0].Kind, Is.EqualTo(FileChangeKind.Modified));
@@ -69,13 +69,13 @@ public class GeneratedSourcesTests
 	}
 
 	[Test]
-	public void ReportsWhatOnlyOneSideGenerated()
+	public async Task ReportsWhatOnlyOneSideGenerated()
 	{
 		string baseTree = NewDirectory(), headTree = NewDirectory();
 		Write(baseTree, "src/Lib/obj/Debug/net10.0/generated/G/E/Gone.g.cs", "was here\n");
 		Write(headTree, "src/Lib/obj/Debug/net10.0/generated/G/E/New.g.cs", "is here\n");
 
-		var files = GeneratedSources.DiffAsync(baseTree, headTree).GetAwaiter().GetResult();
+		var files = await GeneratedSources.DiffAsync(baseTree, headTree);
 
 		Assert.That(files.Select(f => (f.Path, f.Kind)), Is.EquivalentTo(new[] {
 			("src/Lib/generated/G/E/Gone.g.cs", FileChangeKind.Deleted),
@@ -84,24 +84,24 @@ public class GeneratedSourcesTests
 	}
 
 	[Test]
-	public void LeavesOutGeneratedFilesTheChangeDidNotMove()
+	public async Task LeavesOutGeneratedFilesTheChangeDidNotMove()
 	{
 		string baseTree = NewDirectory(), headTree = NewDirectory();
 		Write(baseTree, "src/Lib/obj/Debug/net10.0/generated/G/E/Same.g.cs", "unchanged\n");
 		Write(headTree, "src/Lib/obj/Debug/net10.0/generated/G/E/Same.g.cs", "unchanged\n");
 
-		Assert.That(GeneratedSources.DiffAsync(baseTree, headTree).GetAwaiter().GetResult(), Is.Empty,
+		Assert.That(await GeneratedSources.DiffAsync(baseTree, headTree), Is.Empty,
 			"a generator whose output stands still is not part of the change");
 	}
 
 	[Test]
-	public void CarriesWhereEachSideCanBeReadFrom()
+	public async Task CarriesWhereEachSideCanBeReadFrom()
 	{
 		string baseTree = NewDirectory(), headTree = NewDirectory();
 		Write(baseTree, "src/Lib/obj/Debug/net10.0/generated/G/E/Thing.g.cs", "before\n");
 		Write(headTree, "src/Lib/obj/Debug/net10.0/generated/G/E/Thing.g.cs", "after\n");
 
-		var file = GeneratedSources.DiffAsync(baseTree, headTree).GetAwaiter().GetResult().Single();
+		var file = (await GeneratedSources.DiffAsync(baseTree, headTree)).Single();
 
 		// Nothing can read these out of a commit, so the diff has to say where they are.
 		Assert.That(file.IsGenerated, Is.True);


### PR DESCRIPTION
Audit of every `.Result` / `GetAwaiter().GetResult()` on a Task in `src` and `tests` (vendored tree-view code excluded).

## Real problems (fixed)

- `src/Stampeded.RoslynLsp/RoslynLspServer.cs` `Overlay`: called the workspace's `GetDocumentTextAsync` and read `.Result` from inside `HandleNotificationAsync`, which is already async. The method really does await Roslyn's `GetTextAsync`. Now `OverlayAsync`, awaited with the notification's cancellation token.
- `src/Stampeded.RoslynLsp/RoslynLspServer.cs` `Notify`: blocked on `SendAsync(...).GetAwaiter().GetResult()`, waiting on the write semaphore and a stream write. Its only caller is `ReportState`, an `Action` subscribed to `StateChanged`, so it cannot await. Now `NotifyAsync` returns the send task and `ReportState` fires it with a faulted-continuation that writes to the log. Ordering survives: `SemaphoreSlim.WaitAsync` queues waiters FIFO and each call reaches the wait synchronously before yielding. Neither case deadlocked today (no synchronization context in a console server), but both parked a thread-pool thread while another response held the lock.

## Not problems (left alone)

- `src/Stampeded/Documents/DiffDocumentView.axaml.cs` and `src/Stampeded/Documents/SideBySideDocumentView.axaml.cs`: `regions.Result` is read only inside an `IsCompletedSuccessfully` check. Nothing blocks. This is the documented pattern: an in-process parser answers before it is asked, and the diff view awaits the language-server case separately.
- `src/Stampeded/Panes/TestsPaneViewModel.cs`: `row.Result` is the `TestResult` record property on `TestRow`, not a Task.

## Nit (fixed)

- `tests/Stampeded.Core.Tests/GeneratedSourcesTests.cs`: four tests called `DiffAsync(...).GetAwaiter().GetResult()`. NUnit runs `async Task` tests natively, so they now await.

Build clean, `GeneratedSourcesTests` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
